### PR TITLE
Add action for creating Purescript file

### DIFF
--- a/src/main/java/org/purescript/ide/actions/CreateFileAction.kt
+++ b/src/main/java/org/purescript/ide/actions/CreateFileAction.kt
@@ -1,0 +1,106 @@
+package org.purescript.ide.actions
+
+import com.intellij.ide.actions.CreateFileFromTemplateAction
+import com.intellij.ide.actions.CreateFileFromTemplateDialog
+import com.intellij.ide.fileTemplates.FileTemplate
+import com.intellij.ide.fileTemplates.FileTemplateManager
+import com.intellij.ide.fileTemplates.actions.AttributesDefaults
+import com.intellij.ide.fileTemplates.ui.CreateFromTemplateDialog
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.InputValidatorEx
+import com.intellij.psi.PsiDirectory
+import com.intellij.psi.PsiFile
+import org.purescript.icons.PSIcons
+import java.nio.file.Paths
+import java.util.*
+
+class CreateFileAction : CreateFileFromTemplateAction(TITLE, "", PSIcons.FILE) {
+    override fun buildDialog(project: Project, directory: PsiDirectory, builder: CreateFileFromTemplateDialog.Builder) {
+        /*
+         *  If we add more kinds here, IntelliJ will prompt for which kind
+         *  you want to create when invoking the action.
+         *
+         *  All template names must correspond to a file in [/src/main/resources/fileTemplates/internal],
+         *  and to a <internalFileTemplate/> in [src/main/resources/META-INF/plugin.xml]
+         */
+        builder.setTitle(TITLE)
+            .addKind("Module", PSIcons.FILE, "Purescript Module")
+            .setValidator(NAME_VALIDATOR)
+    }
+
+    override fun getActionName(directory: PsiDirectory?, newName: String, templateName: String?): String =
+        TITLE
+
+    /**
+     * We override this so that we can control the properties
+     * that are sent into the template. In particular, we want
+     * `MODULE_NAME` to be available for the template engine.
+     *
+     * It looks a little hacky using the [CreateFromTemplateDialog] to create the file,
+     * since we don't want any additional dialogs, but I couldn't find an easier way to do it.
+     * The Julia plugin project is passing custom properties this way:
+     *      [https://github.com/JuliaEditorSupport/julia-intellij/blob/master/src/org/ice1000/julia/lang/action/julia-file-actions.kt]
+     */
+    override fun createFileFromTemplate(name: String, template: FileTemplate, dir: PsiDirectory): PsiFile? {
+        val lastModuleName = name.removeSuffix(".purs")
+            .split(".")
+            .last()
+        val fileName = "$lastModuleName.purs"
+        val properties = getProperties(lastModuleName, dir)
+
+        // We need to set AttributesDefaults here, otherwise we will get prompted for the file name
+        val dialog = CreateFromTemplateDialog(
+            dir.project,
+            dir,
+            template,
+            AttributesDefaults(fileName).withFixedName(true),
+            properties
+        )
+
+        return dialog.create()?.containingFile
+    }
+
+    private fun getProperties(lastModuleName: String, dir: PsiDirectory): Properties {
+        val moduleName = Paths.get(dir.virtualFile.path)
+            .reversed()
+            .takeWhile { "$it" != "src" && "$it" != "test" }
+            .reversed()
+            .joinToString(".")
+            .let { "$it.$lastModuleName" }
+            .removePrefix(".")
+
+        val properties = FileTemplateManager.getInstance(dir.project).defaultProperties
+        properties += "MODULE_NAME" to moduleName
+
+        return properties
+    }
+
+    companion object {
+        const val TITLE = "New Purescript File"
+
+        internal val NAME_VALIDATOR = object : InputValidatorEx {
+            override fun checkInput(inputString: String?): Boolean =
+                true
+
+            override fun canClose(inputString: String?): Boolean =
+                getErrorText(inputString) == null
+
+            override fun getErrorText(inputString: String?): String? {
+                if (inputString.isNullOrBlank()) {
+                    return "File name cannot be empty"
+                }
+                if (!inputString.first().isUpperCase()) {
+                    return "File name must start with a capital letter"
+                }
+                return null
+            }
+        }
+    }
+
+    /**
+     * Exposed only for testing purposes.
+     */
+    internal fun internalCreateFile(name: String, templateName: String, dir: PsiDirectory): PsiFile? {
+        return createFile(name, templateName, dir)
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -36,6 +36,7 @@
 
   <extensions defaultExtensionNs="com.intellij">
     <!-- Add your extensions here -->
+    <internalFileTemplate name="Purescript Module"/>
     <!-- LSP server support START-->
     <postStartupActivity
         implementation="org.purescript.PSStartupActivity"
@@ -90,7 +91,12 @@
   </extensions>
 
   <actions>
-    <!-- Add your actions here -->
+    <action id="Purescript.NewFile"
+            class="org.purescript.ide.actions.CreateFileAction"
+            text="Purescript File"
+            description="Create new Purescript file">
+      <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFile"/>
+    </action>
   </actions>
   <!-- Language Server support -->
   <application-components>

--- a/src/main/resources/fileTemplates/internal/Purescript Module.purs.ft
+++ b/src/main/resources/fileTemplates/internal/Purescript Module.purs.ft
@@ -1,0 +1,3 @@
+module ${MODULE_NAME} where
+
+import Prelude

--- a/src/test/java/org/purescript/ide/actions/CreateFileActionNameValidatorTest.kt
+++ b/src/test/java/org/purescript/ide/actions/CreateFileActionNameValidatorTest.kt
@@ -1,0 +1,38 @@
+package org.purescript.ide.actions
+
+import junit.framework.TestCase
+
+
+class CreateFileActionNameValidatorTest : TestCase() {
+    fun `test lowercase is rejected`() {
+        assertFalse(CreateFileAction.NAME_VALIDATOR.canClose("foo"))
+    }
+
+    fun `test uppercase is accepted`() {
+        assertTrue(CreateFileAction.NAME_VALIDATOR.canClose("Foo"))
+    }
+
+    fun `test empty is rejected`() {
+        assertFalse(CreateFileAction.NAME_VALIDATOR.canClose(""))
+    }
+
+    fun `test blank is rejected`() {
+        assertFalse(CreateFileAction.NAME_VALIDATOR.canClose("  "))
+    }
+
+    fun `test null is rejected`() {
+        assertFalse(CreateFileAction.NAME_VALIDATOR.canClose(null))
+    }
+
+    fun `test qualified is accepted`() {
+        assertTrue(CreateFileAction.NAME_VALIDATOR.canClose("Foo.Bar"))
+    }
+
+    fun `test weird initial character is rejected`() {
+        assertFalse(CreateFileAction.NAME_VALIDATOR.canClose(".Foo"))
+        assertFalse(CreateFileAction.NAME_VALIDATOR.canClose(" Foo"))
+        assertFalse(CreateFileAction.NAME_VALIDATOR.canClose("*Foo"))
+        assertFalse(CreateFileAction.NAME_VALIDATOR.canClose("`Foo"))
+        assertFalse(CreateFileAction.NAME_VALIDATOR.canClose("3Foo"))
+    }
+}

--- a/src/test/java/org/purescript/ide/actions/CreateFileActionTest.kt
+++ b/src/test/java/org/purescript/ide/actions/CreateFileActionTest.kt
@@ -1,0 +1,93 @@
+package org.purescript.ide.actions
+
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.psi.PsiFile
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+/**
+ * The method called for creating the file, [com.intellij.ide.fileTemplates.ui.CreateFromTemplateDialog.create],
+ * actually changes the name of the file when running as a unit test. Files are always called `Purescript Module.purs`
+ */
+const val fileName = "Purescript Module.purs"
+
+class CreateFileActionTest : BasePlatformTestCase() {
+    fun `test create simple purescript file`() {
+        performCreateFileAction("Foo")
+        myFixture.checkResult(
+            fileName,
+            getExpectedModuleBody("Foo"),
+            false
+        )
+    }
+
+    fun `test strips purs suffix`() {
+        performCreateFileAction("Foo.purs")
+        myFixture.checkResult(
+            fileName,
+            getExpectedModuleBody("Foo"),
+            false
+        )
+    }
+
+    fun `test create file in src directory`() {
+        performCreateFileAction("Bar", "src")
+        myFixture.checkResult(
+            "src/$fileName",
+            getExpectedModuleBody("Bar"),
+            false
+        )
+    }
+
+    fun `test create file in test directory`() {
+        performCreateFileAction("Bar", "test")
+        myFixture.checkResult(
+            "test/$fileName",
+            getExpectedModuleBody("Bar"),
+            false
+        )
+    }
+
+    fun `test create file in nested directory`() {
+        performCreateFileAction("Bar", "src/Foo")
+        myFixture.checkResult(
+            "src/Foo/$fileName",
+            getExpectedModuleBody("Foo.Bar"),
+            false
+        )
+    }
+
+    fun `test removes purs suffix in nested directory`() {
+        performCreateFileAction("Bar.purs", "src/Foo")
+        myFixture.checkResult(
+            "src/Foo/$fileName",
+            getExpectedModuleBody("Foo.Bar"),
+            false
+        )
+    }
+
+    fun `test create file with full name in nested directory`() {
+        performCreateFileAction("Foo.Bar", "src/Foo")
+        myFixture.checkResult(
+            "src/Foo/$fileName",
+            getExpectedModuleBody("Foo.Bar"),
+            false
+        )
+    }
+
+    private fun getExpectedModuleBody(moduleName: String): String {
+        return """
+            module $moduleName where
+
+            import Prelude
+
+            """.trimIndent()
+    }
+
+    private fun performCreateFileAction(name: String, directoryName: String = ""): PsiFile {
+        val file = myFixture.tempDirFixture.findOrCreateDir(directoryName)
+        val directory = myFixture.psiManager.findDirectory(file)!!
+        val action = ActionManager.getInstance().getAction("Purescript.NewFile") as CreateFileAction
+        return action.internalCreateFile(name, "Purescript Module", directory)!!
+    }
+
+}

--- a/src/test/java/org/purescript/ide/actions/CreateFileActionTest.kt
+++ b/src/test/java/org/purescript/ide/actions/CreateFileActionTest.kt
@@ -6,7 +6,11 @@ import com.intellij.testFramework.fixtures.BasePlatformTestCase
 
 /**
  * The method called for creating the file, [com.intellij.ide.fileTemplates.ui.CreateFromTemplateDialog.create],
- * actually changes the name of the file when running as a unit test. Files are always called `Purescript Module.purs`
+ * actually changes behaviour when running as a unit test.
+ * In particular, the name of the file is different.
+ *
+ * In our case, files are always called `Purescript Module.purs`,
+ * and that means that we cannot test that the file is named correctly.
  */
 const val fileName = "Purescript Module.purs"
 


### PR DESCRIPTION
This PR will add an action for creating new module files. It performs some basic name validation, and prefixes the module if it's created in a hierarchy.


<img width="1008" alt="Navigate to new" src="https://user-images.githubusercontent.com/5345337/107117348-11458680-687a-11eb-9b86-912e06390500.png">
<img width="1004" alt="Enter module name" src="https://user-images.githubusercontent.com/5345337/107117354-173b6780-687a-11eb-9944-622f6e901e47.png">
<img width="1004" alt="File created" src="https://user-images.githubusercontent.com/5345337/107117358-1a365800-687a-11eb-8d3f-67e319070a95.png">
