### PR TITLE
Add resolution, completion, and inspection for exported modules

### DIFF
--- a/src/main/java/org/purescript/ide/inspections/PSUnresolvedReferenceInspection.kt
+++ b/src/main/java/org/purescript/ide/inspections/PSUnresolvedReferenceInspection.kt
@@ -5,6 +5,7 @@ import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
+import org.purescript.psi.PSExportedModule
 import org.purescript.psi.PSExportedValue
 
 class PSUnresolvedReferenceInspection : LocalInspectionTool() {
@@ -18,6 +19,15 @@ class PSUnresolvedReferenceInspection : LocalInspectionTool() {
                             holder.registerProblem(
                                 element,
                                 "Unresolved reference '${element.name}'",
+                                ProblemHighlightType.LIKE_UNKNOWN_SYMBOL
+                            )
+                        }
+                    }
+                    is PSExportedModule -> {
+                        if (element.reference.multiResolve(false).isEmpty()) {
+                            holder.registerProblem(
+                                element,
+                                "Unresolved module '${element.name}'",
                                 ProblemHighlightType.LIKE_UNKNOWN_SYMBOL
                             )
                         }

--- a/src/main/java/org/purescript/psi/PSExportedItem.kt
+++ b/src/main/java/org/purescript/psi/PSExportedItem.kt
@@ -2,6 +2,7 @@ package org.purescript.psi
 
 import com.intellij.lang.ASTNode
 import org.purescript.file.PSFile
+import org.purescript.psi.`var`.ExportedModuleReference
 import org.purescript.psi.`var`.ExportedValueReference
 
 sealed class PSExportedItem(node: ASTNode) : PSPsiElement(node) {
@@ -14,9 +15,18 @@ class PSExportedData(node: ASTNode) : PSExportedItem(node) {
 
 class PSExportedClass(node: ASTNode) : PSExportedItem(node)
 class PSExportedKind(node: ASTNode) : PSExportedItem(node)
-class PSExportedModule(node: ASTNode) : PSExportedItem(node)
 class PSExportedOperator(node: ASTNode) : PSExportedItem(node)
 class PSExportedType(node: ASTNode) : PSExportedItem(node)
+
+class PSExportedModule(node: ASTNode) : PSExportedItem(node) {
+    val qualifiedIdentifier = findNotNullChildByClass(PSProperName::class.java)
+
+    override fun getName(): String = qualifiedIdentifier.name
+
+    override fun getReference(): ExportedModuleReference {
+        return ExportedModuleReference(this)
+    }
+}
 
 class PSExportedValue(node: ASTNode) : PSExportedItem(node) {
 

--- a/src/main/java/org/purescript/psi/PSImportDeclarationImpl.kt
+++ b/src/main/java/org/purescript/psi/PSImportDeclarationImpl.kt
@@ -1,9 +1,12 @@
 package org.purescript.psi
 
 import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
 import com.intellij.psi.SyntaxTraverser
 import com.intellij.psi.impl.source.tree.LeafPsiElement
+import com.intellij.psi.util.siblings
+import org.purescript.parser.PSTokens
 
 class PSImportDeclarationImpl(node: ASTNode) : PSPsiElement(node) {
 
@@ -38,7 +41,7 @@ class PSImportDeclarationImpl(node: ASTNode) : PSPsiElement(node) {
         return ModuleReference(this)
     }
 
-    private val importedModule get(): PSModule? = ModuleReference(this).resolve()
+    val importedModule get(): PSModule? = ModuleReference(this).resolve()
 
     val importedValues
         get(): Sequence<PSValueDeclaration> =

--- a/src/main/java/org/purescript/psi/var/ExportedModuleReference.kt
+++ b/src/main/java/org/purescript/psi/var/ExportedModuleReference.kt
@@ -1,0 +1,29 @@
+package org.purescript.psi.`var`
+
+import com.intellij.psi.PsiElementResolveResult.createResults
+import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.ResolveResult
+import org.purescript.psi.PSExportedModule
+import org.purescript.psi.PSImportDeclarationImpl
+
+class ExportedModuleReference(exportedModule: PSExportedModule) : PsiReferenceBase.Poly<PSExportedModule>(
+    exportedModule,
+    exportedModule.qualifiedIdentifier.textRangeInParent,
+    false
+) {
+
+    override fun getVariants(): Array<String> {
+        return candidates.mapNotNull { it.importName?.name }
+            .toTypedArray()
+    }
+
+    override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> {
+        val importDeclarations = candidates.filter { it.importName?.name == myElement.name }
+        val modules = importDeclarations.mapNotNull { it.importedModule }
+        return createResults(modules)
+    }
+
+    private val candidates: Array<PSImportDeclarationImpl>
+        get() =
+            myElement.module.importDeclarations
+}

--- a/src/test/java/org/purescript/ide/inspections/PSUnresolvedReferenceInspectionTest.kt
+++ b/src/test/java/org/purescript/ide/inspections/PSUnresolvedReferenceInspectionTest.kt
@@ -38,4 +38,51 @@ class PSUnresolvedReferenceInspectionTest : BasePlatformTestCase() {
         myFixture.enableInspections(PSUnresolvedReferenceInspection())
         myFixture.checkHighlighting()
     }
+
+    fun `test reports unresolved exported module (not imported)`() {
+        myFixture.configureByText(
+            "Bar.purs",
+            """
+            module Bar where
+            """.trimIndent()
+        )
+        myFixture.configureByText(
+            "Foo.purs",
+            """
+            module Foo (<error descr="Unresolved module 'Bar'">module Bar</error>) where
+            """.trimIndent()
+        )
+        myFixture.enableInspections(PSUnresolvedReferenceInspection())
+        myFixture.checkHighlighting()
+    }
+
+    fun `test reports unresolved exported module (not exists)`() {
+        myFixture.configureByText(
+            "Foo.purs",
+            """
+            module Foo (<error descr="Unresolved module 'Bar'">module Bar</error>) where
+            import Bar
+            """.trimIndent()
+        )
+        myFixture.enableInspections(PSUnresolvedReferenceInspection())
+        myFixture.checkHighlighting()
+    }
+
+    fun `test doesn't report resolved exported module`() {
+        myFixture.configureByText(
+            "Bar.purs",
+            """
+            module Bar where
+            """.trimIndent()
+        )
+        myFixture.configureByText(
+            "Foo.purs",
+            """
+            module Foo (module Bar) where
+            import Bar
+            """.trimIndent()
+        )
+        myFixture.enableInspections(PSUnresolvedReferenceInspection())
+        myFixture.checkHighlighting()
+    }
 }

--- a/src/test/java/org/purescript/psi/var/ExportedModuleReferenceTest.kt
+++ b/src/test/java/org/purescript/psi/var/ExportedModuleReferenceTest.kt
@@ -1,0 +1,70 @@
+package org.purescript.psi.`var`
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import junit.framework.TestCase
+import org.purescript.file.PSFile
+import org.purescript.psi.PSExportedModule
+
+class ExportedModuleReferenceTest : BasePlatformTestCase() {
+
+    fun `test completes imported modules`() {
+        myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo (module <caret>) where
+                import Prelude
+                import Data.String
+            """.trimIndent()
+        )
+        myFixture.testCompletionVariants("Foo.purs", "Prelude", "Data.String")
+    }
+
+    fun `test resolves to imported module`() {
+        val fileFoo = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo (module Bar) where
+                import Bar
+            """.trimIndent()
+        ) as PSFile
+        val fileBar = myFixture.configureByText(
+            "Bar.purs",
+            """
+                module Bar where
+            """.trimIndent()
+        ) as PSFile
+        val exportedModule = fileFoo.module.exportList!!.exportedItems.single() as PSExportedModule
+
+        TestCase.assertTrue(exportedModule.reference.isReferenceTo(fileBar.module))
+    }
+
+    fun `test does not resolve to module if not imported`() {
+        val fileFoo = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo (module Bar) where
+            """.trimIndent()
+        ) as PSFile
+        val fileBar = myFixture.configureByText(
+            "Bar.purs",
+            """
+                module Bar where
+            """.trimIndent()
+        ) as PSFile
+        val exportedModule = fileFoo.module.exportList!!.exportedItems.single() as PSExportedModule
+
+        TestCase.assertFalse(exportedModule.reference.isReferenceTo(fileBar.module))
+    }
+
+    fun `test does not resolve to module if it does not exist`() {
+        val fileFoo = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo (module Bar) where
+            """.trimIndent()
+        ) as PSFile
+        val exportedModule = fileFoo.module.exportList!!.exportedItems.single() as PSExportedModule
+
+        TestCase.assertTrue(exportedModule.reference.multiResolve(false).isEmpty())
+    }
+}


### PR DESCRIPTION

https://user-images.githubusercontent.com/5345337/109198023-05285700-779e-11eb-959f-8849872d958e.mov

Exporting aliased imported modules is not yet supported. Lets add that after reworking the PSI structure for import declarations.