### PR TITLE
Update exported value declarations to account for more kinds of exported values

### DIFF
--- a/src/main/java/org/purescript/parser/PSParserDefinition.kt
+++ b/src/main/java/org/purescript/parser/PSParserDefinition.kt
@@ -16,6 +16,7 @@ import org.purescript.file.PSFileStubType
 import org.purescript.lexer.PSLexer
 import org.purescript.psi.*
 import org.purescript.psi.`var`.PSVar
+import org.purescript.psi.import.*
 
 class PSParserDefinition : ParserDefinition, PSTokens {
     override fun createLexer(project: Project): Lexer {

--- a/src/main/java/org/purescript/psi/ModuleReference.kt
+++ b/src/main/java/org/purescript/psi/ModuleReference.kt
@@ -5,6 +5,7 @@ import com.intellij.psi.PsiReferenceBase
 import com.intellij.psi.search.FilenameIndex
 import com.intellij.psi.search.GlobalSearchScope
 import org.purescript.file.PSFile
+import org.purescript.psi.import.PSImportDeclarationImpl
 
 class ModuleReference(element: PSImportDeclarationImpl) : PsiReferenceBase<PSImportDeclarationImpl>(
     element,

--- a/src/main/java/org/purescript/psi/PSExportedItem.kt
+++ b/src/main/java/org/purescript/psi/PSExportedItem.kt
@@ -4,6 +4,7 @@ import com.intellij.lang.ASTNode
 import org.purescript.file.PSFile
 import org.purescript.psi.`var`.ExportedModuleReference
 import org.purescript.psi.`var`.ExportedValueReference
+import org.purescript.psi.import.PSImportDeclarationImpl
 
 sealed class PSExportedItem(node: ASTNode) : PSPsiElement(node) {
     val module: PSModule get() = (containingFile as PSFile).module
@@ -20,6 +21,11 @@ class PSExportedType(node: ASTNode) : PSExportedItem(node)
 
 class PSExportedModule(node: ASTNode) : PSExportedItem(node) {
     val qualifiedIdentifier = findNotNullChildByClass(PSProperName::class.java)
+
+    val importDeclaration : PSImportDeclarationImpl? get() =
+        module.importDeclarations.singleOrNull {
+            it.name == qualifiedIdentifier.name
+        }
 
     override fun getName(): String = qualifiedIdentifier.name
 

--- a/src/main/java/org/purescript/psi/PSModule.kt
+++ b/src/main/java/org/purescript/psi/PSModule.kt
@@ -12,6 +12,7 @@ class PSModule(node: ASTNode) :
     PSPsiElement(node),
     PsiNameIdentifierOwner,
     DocCommentOwner {
+
     override fun getName(): String {
         return nameIdentifier.name
     }
@@ -46,13 +47,24 @@ class PSModule(node: ASTNode) :
         get() =
             findChildrenByClass(PSForeignValueDeclaration::class.java)
 
+    /**
+     * All import declarations in this module
+     */
     val importDeclarations: Array<PSImportDeclarationImpl>
         get() =
             findChildrenByClass(PSImportDeclarationImpl::class.java)
 
+    /**
+     * All values declared in this module
+     */
     val valueDeclarations: Array<PSValueDeclaration>
         get() = findChildrenByClass(PSValueDeclaration::class.java)
 
+    /**
+     * All the value declarations that this module exports, including
+     * both values this module declares and values that this module
+     * re-exports from other modules.
+     */
     val exportedValueDeclarations: List<PSValueDeclaration>
         get() {
             val explicitlyExportedItems = exportList?.exportedItems

--- a/src/main/java/org/purescript/psi/PSModule.kt
+++ b/src/main/java/org/purescript/psi/PSModule.kt
@@ -5,6 +5,7 @@ import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNameIdentifierOwner
 import org.purescript.features.DocCommentOwner
+import org.purescript.psi.import.PSImportDeclarationImpl
 
 
 class PSModule(node: ASTNode) :

--- a/src/main/java/org/purescript/psi/PSModule.kt
+++ b/src/main/java/org/purescript/psi/PSModule.kt
@@ -82,7 +82,7 @@ class PSModule(node: ASTNode) :
 
             explicitlyExportedItems.filterIsInstance<PSExportedModule>()
                 .mapNotNull { it.importDeclaration }
-                .flatMapTo(exportedValueDeclarations) { it.importedValues }
+                .flatMapTo(exportedValueDeclarations) { it.importedValueDeclarations }
 
             return exportedValueDeclarations
         }
@@ -91,7 +91,7 @@ class PSModule(node: ASTNode) :
         get() =
             importDeclarations
                 .filter { it.name in reexportedModuleNames }
-                .flatMap { it.importedValues }
+                .flatMap { it.importedValueDeclarations }
                 .asSequence()
 
     val reexportedModuleNames: List<String>

--- a/src/main/java/org/purescript/psi/PSModule.kt
+++ b/src/main/java/org/purescript/psi/PSModule.kt
@@ -87,13 +87,6 @@ class PSModule(node: ASTNode) :
             return exportedValueDeclarations
         }
 
-    private val valuesFromReexportedModules
-        get() =
-            importDeclarations
-                .filter { it.name in reexportedModuleNames }
-                .flatMap { it.importedValueDeclarations }
-                .asSequence()
-
     val reexportedModuleNames: List<String>
         get() =
             exportList?.exportedItems?.filterIsInstance(PSExportedModule::class.java)

--- a/src/main/java/org/purescript/psi/PSModule.kt
+++ b/src/main/java/org/purescript/psi/PSModule.kt
@@ -90,7 +90,7 @@ class PSModule(node: ASTNode) :
     val reexportedModuleNames: List<String>
         get() =
             exportList?.exportedItems?.filterIsInstance(PSExportedModule::class.java)
-                ?.map { it.text.removePrefix("module").trim() }
+                ?.map { it.name }
                 ?.toList()
                 ?: emptyList()
 

--- a/src/main/java/org/purescript/psi/PSModule.kt
+++ b/src/main/java/org/purescript/psi/PSModule.kt
@@ -69,8 +69,8 @@ class PSModule(node: ASTNode) :
             }
 
             explicitlyExportedItems.filterIsInstance<PSExportedModule>()
-                .mapNotNull { it.importDeclaration?.importedValues }
-                .flatMapTo(exportedValueDeclarations) { it }
+                .mapNotNull { it.importDeclaration }
+                .flatMapTo(exportedValueDeclarations) { it.importedValues }
 
             return exportedValueDeclarations
         }

--- a/src/main/java/org/purescript/psi/import/PSImportAlias.kt
+++ b/src/main/java/org/purescript/psi/import/PSImportAlias.kt
@@ -1,8 +1,10 @@
-package org.purescript.psi
+package org.purescript.psi.import
 
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNamedElement
+import org.purescript.psi.PSProperName
+import org.purescript.psi.PSPsiElement
 
 /**
  * The alias of an import declaration.
@@ -16,7 +18,8 @@ import com.intellij.psi.PsiNamedElement
  */
 class PSImportAlias(node: ASTNode) : PSPsiElement(node), PsiNamedElement {
 
-    private val properName: PSProperName get() =
+    private val properName: PSProperName
+        get() =
         findNotNullChildByClass(PSProperName::class.java)
 
     override fun setName(name: String): PsiElement? {

--- a/src/main/java/org/purescript/psi/import/PSImportDeclarationImpl.kt
+++ b/src/main/java/org/purescript/psi/import/PSImportDeclarationImpl.kt
@@ -67,7 +67,7 @@ class PSImportDeclarationImpl(node: ASTNode) : PSPsiElement(node) {
 
     val importedModule get(): PSModule? = ModuleReference(this).resolve()
 
-    val importedValues
+    val importedValueDeclarations
         get(): Sequence<PSValueDeclaration> =
             importedModule?.let { importedModule ->
                 when {

--- a/src/main/java/org/purescript/psi/import/PSImportDeclarationImpl.kt
+++ b/src/main/java/org/purescript/psi/import/PSImportDeclarationImpl.kt
@@ -1,12 +1,8 @@
-package org.purescript.psi
+package org.purescript.psi.import
 
 import com.intellij.lang.ASTNode
-import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
-import com.intellij.psi.SyntaxTraverser
-import com.intellij.psi.impl.source.tree.LeafPsiElement
-import com.intellij.psi.util.siblings
-import org.purescript.parser.PSTokens
+import org.purescript.psi.*
 
 class PSImportDeclarationImpl(node: ASTNode) : PSPsiElement(node) {
 

--- a/src/main/java/org/purescript/psi/import/PSImportDeclarationImpl.kt
+++ b/src/main/java/org/purescript/psi/import/PSImportDeclarationImpl.kt
@@ -4,6 +4,14 @@ import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiReference
 import org.purescript.psi.*
 
+/**
+ * An import declaration, as found near the top a module.
+ *
+ * E.g.
+ * ```
+ * import Foo.Bar hiding (a, b, c) as FB
+ * ```
+ */
 class PSImportDeclarationImpl(node: ASTNode) : PSPsiElement(node) {
 
     /**

--- a/src/main/java/org/purescript/psi/import/PSImportList.kt
+++ b/src/main/java/org/purescript/psi/import/PSImportList.kt
@@ -1,8 +1,9 @@
-package org.purescript.psi
+package org.purescript.psi.import
 
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import org.purescript.parser.PSTokens
+import org.purescript.psi.PSPsiElement
 
 /**
  * The import list in an import declaration.

--- a/src/main/java/org/purescript/psi/import/PSImportedDataMember.kt
+++ b/src/main/java/org/purescript/psi/import/PSImportedDataMember.kt
@@ -1,5 +1,6 @@
-package org.purescript.psi
+package org.purescript.psi.import
 
 import com.intellij.lang.ASTNode
+import org.purescript.psi.PSPsiElement
 
 class PSImportedDataMember(node: ASTNode) : PSPsiElement(node)

--- a/src/main/java/org/purescript/psi/import/PSImportedDataMemberList.kt
+++ b/src/main/java/org/purescript/psi/import/PSImportedDataMemberList.kt
@@ -1,8 +1,9 @@
-package org.purescript.psi
+package org.purescript.psi.import
 
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import org.purescript.parser.PSTokens
+import org.purescript.psi.PSPsiElement
 
 class PSImportedDataMemberList(node: ASTNode) : PSPsiElement(node) {
     val doubleDot: PsiElement? get() = findChildByType(PSTokens.DDOT)

--- a/src/main/java/org/purescript/psi/import/PSImportedItem.kt
+++ b/src/main/java/org/purescript/psi/import/PSImportedItem.kt
@@ -1,48 +1,57 @@
-package org.purescript.psi
+package org.purescript.psi.import
 
 import com.intellij.lang.ASTNode
+import org.purescript.psi.PSIdentifierImpl
+import org.purescript.psi.PSProperName
+import org.purescript.psi.PSPsiElement
 
 sealed class PSImportedItem(node: ASTNode) : PSPsiElement(node) {
     abstract override fun getName(): String
 }
 
 class PSImportedClass(node: ASTNode) : PSImportedItem(node) {
-    private val properName: PSProperName get() =
+    private val properName: PSProperName
+        get() =
         findNotNullChildByClass(PSProperName::class.java)
 
     override fun getName(): String = properName.name
 }
 
 class PSImportedData(node: ASTNode) : PSImportedItem(node) {
-    private val properName: PSProperName get() =
+    private val properName: PSProperName
+        get() =
         findNotNullChildByClass(PSProperName::class.java)
 
     override fun getName(): String = properName.name
 }
 
 class PSImportedKind(node: ASTNode) : PSImportedItem(node) {
-    private val properName: PSProperName get() =
+    private val properName: PSProperName
+        get() =
         findNotNullChildByClass(PSProperName::class.java)
 
     override fun getName(): String = properName.name
 }
 
 class PSImportedOperator(node: ASTNode) : PSImportedItem(node) {
-    private val identifier: PSIdentifierImpl get() =
+    private val identifier: PSIdentifierImpl
+        get() =
         findNotNullChildByClass(PSIdentifierImpl::class.java)
 
     override fun getName(): String = identifier.name
 }
 
 class PSImportedType(node: ASTNode) : PSImportedItem(node) {
-    private val identifier: PSIdentifierImpl get() =
+    private val identifier: PSIdentifierImpl
+        get() =
         findNotNullChildByClass(PSIdentifierImpl::class.java)
 
     override fun getName(): String = identifier.name
 }
 
 class PSImportedValue(node: ASTNode) : PSImportedItem(node) {
-    private val identifier: PSIdentifierImpl get() =
+    private val identifier: PSIdentifierImpl
+        get() =
         findNotNullChildByClass(PSIdentifierImpl::class.java)
 
     override fun getName(): String = identifier.name

--- a/src/main/java/org/purescript/psi/import/PSImportedItem.kt
+++ b/src/main/java/org/purescript/psi/import/PSImportedItem.kt
@@ -12,7 +12,7 @@ sealed class PSImportedItem(node: ASTNode) : PSPsiElement(node) {
 class PSImportedClass(node: ASTNode) : PSImportedItem(node) {
     private val properName: PSProperName
         get() =
-        findNotNullChildByClass(PSProperName::class.java)
+            findNotNullChildByClass(PSProperName::class.java)
 
     override fun getName(): String = properName.name
 }
@@ -20,7 +20,7 @@ class PSImportedClass(node: ASTNode) : PSImportedItem(node) {
 class PSImportedData(node: ASTNode) : PSImportedItem(node) {
     private val properName: PSProperName
         get() =
-        findNotNullChildByClass(PSProperName::class.java)
+            findNotNullChildByClass(PSProperName::class.java)
 
     override fun getName(): String = properName.name
 }
@@ -28,7 +28,7 @@ class PSImportedData(node: ASTNode) : PSImportedItem(node) {
 class PSImportedKind(node: ASTNode) : PSImportedItem(node) {
     private val properName: PSProperName
         get() =
-        findNotNullChildByClass(PSProperName::class.java)
+            findNotNullChildByClass(PSProperName::class.java)
 
     override fun getName(): String = properName.name
 }
@@ -36,7 +36,7 @@ class PSImportedKind(node: ASTNode) : PSImportedItem(node) {
 class PSImportedOperator(node: ASTNode) : PSImportedItem(node) {
     private val identifier: PSIdentifierImpl
         get() =
-        findNotNullChildByClass(PSIdentifierImpl::class.java)
+            findNotNullChildByClass(PSIdentifierImpl::class.java)
 
     override fun getName(): String = identifier.name
 }
@@ -44,7 +44,7 @@ class PSImportedOperator(node: ASTNode) : PSImportedItem(node) {
 class PSImportedType(node: ASTNode) : PSImportedItem(node) {
     private val identifier: PSIdentifierImpl
         get() =
-        findNotNullChildByClass(PSIdentifierImpl::class.java)
+            findNotNullChildByClass(PSIdentifierImpl::class.java)
 
     override fun getName(): String = identifier.name
 }
@@ -52,7 +52,7 @@ class PSImportedType(node: ASTNode) : PSImportedItem(node) {
 class PSImportedValue(node: ASTNode) : PSImportedItem(node) {
     private val identifier: PSIdentifierImpl
         get() =
-        findNotNullChildByClass(PSIdentifierImpl::class.java)
+            findNotNullChildByClass(PSIdentifierImpl::class.java)
 
     override fun getName(): String = identifier.name
 }

--- a/src/main/java/org/purescript/psi/var/ExportedModuleReference.kt
+++ b/src/main/java/org/purescript/psi/var/ExportedModuleReference.kt
@@ -4,7 +4,7 @@ import com.intellij.psi.PsiElementResolveResult.createResults
 import com.intellij.psi.PsiReferenceBase
 import com.intellij.psi.ResolveResult
 import org.purescript.psi.PSExportedModule
-import org.purescript.psi.PSImportDeclarationImpl
+import org.purescript.psi.import.PSImportDeclarationImpl
 
 class ExportedModuleReference(exportedModule: PSExportedModule) : PsiReferenceBase.Poly<PSExportedModule>(
     exportedModule,

--- a/src/main/java/org/purescript/psi/var/ImportedValueReference.kt
+++ b/src/main/java/org/purescript/psi/var/ImportedValueReference.kt
@@ -15,7 +15,7 @@ class ImportedValueReference(element: PSVar) : PsiReferenceBase.Poly<PSVar>(
     override fun getVariants(): Array<PsiNamedElement> {
         val currentModule = myElement.module
         return currentModule.importDeclarations
-            .flatMap { it.importedValues }
+            .flatMap { it.importedValueDeclarations }
             .toTypedArray()
     }
 

--- a/src/test/java/org/purescript/psi/PSImportedClassTest.kt
+++ b/src/test/java/org/purescript/psi/PSImportedClassTest.kt
@@ -3,6 +3,7 @@ package org.purescript.psi
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import junit.framework.TestCase
 import org.purescript.file.PSFile
+import org.purescript.psi.import.PSImportedClass
 
 
 class PSImportedClassTest : BasePlatformTestCase() {

--- a/src/test/java/org/purescript/psi/PSImportedDataTest.kt
+++ b/src/test/java/org/purescript/psi/PSImportedDataTest.kt
@@ -3,6 +3,7 @@ package org.purescript.psi
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import junit.framework.TestCase
 import org.purescript.file.PSFile
+import org.purescript.psi.import.PSImportedData
 
 
 class PSImportedDataTest : BasePlatformTestCase() {

--- a/src/test/java/org/purescript/psi/PSImportedKindTest.kt
+++ b/src/test/java/org/purescript/psi/PSImportedKindTest.kt
@@ -3,6 +3,7 @@ package org.purescript.psi
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import junit.framework.TestCase
 import org.purescript.file.PSFile
+import org.purescript.psi.import.PSImportedKind
 
 
 class PSImportedKindTest : BasePlatformTestCase() {

--- a/src/test/java/org/purescript/psi/PSImportedOperatorTest.kt
+++ b/src/test/java/org/purescript/psi/PSImportedOperatorTest.kt
@@ -3,6 +3,7 @@ package org.purescript.psi
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import junit.framework.TestCase
 import org.purescript.file.PSFile
+import org.purescript.psi.import.PSImportedOperator
 
 
 class PSImportedOperatorTest : BasePlatformTestCase() {

--- a/src/test/java/org/purescript/psi/PSImportedTypeTest.kt
+++ b/src/test/java/org/purescript/psi/PSImportedTypeTest.kt
@@ -3,6 +3,7 @@ package org.purescript.psi
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import junit.framework.TestCase
 import org.purescript.file.PSFile
+import org.purescript.psi.import.PSImportedType
 
 
 class PSImportedTypeTest : BasePlatformTestCase() {

--- a/src/test/java/org/purescript/psi/PSImportedValeTest.kt
+++ b/src/test/java/org/purescript/psi/PSImportedValeTest.kt
@@ -3,6 +3,7 @@ package org.purescript.psi
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import junit.framework.TestCase
 import org.purescript.file.PSFile
+import org.purescript.psi.import.PSImportedValue
 
 
 class PSImportedValeTest : BasePlatformTestCase() {

--- a/src/test/java/org/purescript/psi/var/PSVarTest.kt
+++ b/src/test/java/org/purescript/psi/var/PSVarTest.kt
@@ -145,8 +145,9 @@ class PSVarTest : BasePlatformTestCase() {
         myFixture.addFileToProject(
             "Lib.purs",
             """
-            module Lib where
+            module Lib (z) where
             y = 1
+            z = 2
             """.trimIndent()
         ) as PSFile
         val file = myFixture.addFileToProject(

--- a/src/test/java/org/purescript/psi/var/PSVarTest.kt
+++ b/src/test/java/org/purescript/psi/var/PSVarTest.kt
@@ -165,6 +165,30 @@ class PSVarTest : BasePlatformTestCase() {
         TestCase.assertEquals(0, valueDeclarations.size)
     }
 
+    fun `test var can resolve exported values when exporting all`() {
+        myFixture.addFileToProject(
+            "Lib.purs",
+            """
+            module Lib where
+            y = 1
+            """.trimIndent()
+        ) as PSFile
+        val file = myFixture.addFileToProject(
+            "Main.purs",
+            """
+            module Main where
+            import Lib
+            x = y
+            """.trimIndent()
+        ) as PSFile
+        val psVar = file.getVarByName("y")!!
+        val valueReference =
+            psVar.referenceOfType(ImportedValueReference::class.java)
+        val valueDeclaration = valueReference.multiResolve(false)
+            .single().element as PsiNamedElement
+        TestCase.assertEquals("y", valueDeclaration.name)
+    }
+
     fun `test var can't resolve imported values when hidden`() {
         myFixture.addFileToProject(
             "Lib.purs",


### PR DESCRIPTION
Previous, the property didn't account for modules using the export all syntax. 

I was originally working on another issue, but got caught doing this instead. I think this PR is large enough, so I'll make the changes that I set out to do in another PR.