### PR TITLE
Make find usages work for module declarations with doc comments

### DIFF
--- a/src/main/java/org/purescript/psi/PSModule.kt
+++ b/src/main/java/org/purescript/psi/PSModule.kt
@@ -27,9 +27,7 @@ class PSModule(node: ASTNode) :
         return findChildByClass(PSProperName::class.java)!!
     }
 
-    override fun getTextOffset(): Int {
-        return this.nameIdentifier.textRangeInParent.startOffset
-    }
+    override fun getTextOffset(): Int = nameIdentifier.textOffset
 
     fun getImportDeclarationByName(name: String): PSImportDeclarationImpl? {
         return importDeclarations

--- a/src/test/java/org/purescript/psi/ModuleReferenceTest.kt
+++ b/src/test/java/org/purescript/psi/ModuleReferenceTest.kt
@@ -48,4 +48,25 @@ class ModuleReferenceTest : BasePlatformTestCase() {
 
         assertEquals(module, reference.resolve())
     }
+
+    fun `test finds usage of module with doc comments`() {
+        myFixture.configureByText(
+            "Bar.purs",
+            """
+                -- | This is a doc comment
+                module <caret>Bar where
+            """.trimIndent()
+        )
+        val importDeclaration = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo where
+                import Bar
+            """.trimIndent()
+        ).getImportDeclarations().single()
+
+        val usageInfo = myFixture.testFindUsages("Bar.purs").single()
+
+        assertEquals(importDeclaration, usageInfo.element)
+    }
 }


### PR DESCRIPTION
There was a bug where you couldn't find usages of a module that had doc comments. The reason is that `getTextOffset()` should return the offset in the file, where as it used to return the offset relative to the parent element in `PSModule`. When the module has no doc comments, these offsets are the same.

There is still a bug where it only highlights the first segment in the module name, if the module contains multiple segments: 
```
module Data.String.CodePoints where
```
I haven't figured out why that's the case yet.