### PR TITLE
Fix bug where malformed module headers would cause null pointer exceptions

### DIFF
--- a/src/main/java/org/purescript/features/PSFindUsageProvider.kt
+++ b/src/main/java/org/purescript/features/PSFindUsageProvider.kt
@@ -50,8 +50,7 @@ class PSFindUsageProvider : FindUsagesProvider {
     override fun getDescriptiveName(element: PsiElement): String {
         when (element) {
             is PSValueDeclaration -> {
-                val file = element.containingFile as PSFile
-                return "${file.module.name}.${element.name}"
+                return "${element.module?.name}.${element.name}"
             }
             is PsiNamedElement -> {
                 val name = element.name

--- a/src/main/java/org/purescript/file/PSFile.kt
+++ b/src/main/java/org/purescript/file/PSFile.kt
@@ -16,10 +16,15 @@ class PSFile(viewProvider: FileViewProvider) :
         return "Purescript File"
     }
 
-    val module: PSModule
-        get() = findChildByClass(PSModule::class.java)!!
+    /**
+     * @return the [PSModule] that this file contains,
+     * or null if the module couldn't be parsed
+     */
+    val module: PSModule?
+        get() = findChildByClass(PSModule::class.java)
 
     val topLevelValueDeclarations: Map<String, List<PSValueDeclaration>>
-        get() = module.valueDeclarations.groupBy { it.name }
+        get() = module?.valueDeclarations?.groupBy { it.name }
+            ?: emptyMap()
 
 }

--- a/src/main/java/org/purescript/psi/ModuleReference.kt
+++ b/src/main/java/org/purescript/psi/ModuleReference.kt
@@ -21,7 +21,7 @@ class ModuleReference(element: PSImportDeclarationImpl) : PsiReferenceBase<PSImp
             fileName,
             GlobalSearchScope.allScope(myElement.project)
         ).filterIsInstance<PSFile>()
-            .map { it.module }
+            .mapNotNull { it.module }
             .firstOrNull { it.name == moduleName }
     }
 

--- a/src/main/java/org/purescript/psi/PSPsiElement.kt
+++ b/src/main/java/org/purescript/psi/PSPsiElement.kt
@@ -9,5 +9,5 @@ abstract class PSPsiElement(node: ASTNode) : ASTWrapperPsiElement(node) {
     /**
      * @return the [PSModule] containing this element
      */
-    val module: PSModule get() = (containingFile as PSFile).module
+    val module: PSModule? get() = (containingFile as? PSFile)?.module
 }

--- a/src/main/java/org/purescript/psi/classes/ClassConstraintReference.kt
+++ b/src/main/java/org/purescript/psi/classes/ClassConstraintReference.kt
@@ -15,7 +15,7 @@ class ClassConstraintReference(classConstraint: PSClassConstraint) : PsiReferenc
         candidates.firstOrNull { it.name == myElement.name }
 
     private val candidates: List<PSClassDeclaration>
-        get() = myElement.module.run {
+        get() = myElement.module?.run {
             classDeclarations.toList() + importDeclarations.flatMap { it.importedClassDeclarations }
-        }
+        } ?: emptyList()
 }

--- a/src/main/java/org/purescript/psi/exports/ExportedDataReference.kt
+++ b/src/main/java/org/purescript/psi/exports/ExportedDataReference.kt
@@ -18,10 +18,10 @@ class ExportedDataReference(exportedData: PSExportedData) : PsiReferenceBase<PSE
 
     private val candidates: Array<PsiNamedElement>
         get() =
-            myElement.module.run {
+            myElement.module?.run {
                 arrayOf(
                     *dataDeclarations,
                     *newTypeDeclarations,
                 )
-            }
+            } ?: emptyArray()
 }

--- a/src/main/java/org/purescript/psi/exports/ExportedModuleReference.kt
+++ b/src/main/java/org/purescript/psi/exports/ExportedModuleReference.kt
@@ -20,5 +20,5 @@ class ExportedModuleReference(exportedModule: PSExportedModule) : PsiReferenceBa
 
     private val candidates: Array<PSImportDeclarationImpl>
         get() =
-            myElement.module.importDeclarations
+            myElement.module?.importDeclarations ?: emptyArray()
 }

--- a/src/main/java/org/purescript/psi/exports/ExportedValueReference.kt
+++ b/src/main/java/org/purescript/psi/exports/ExportedValueReference.kt
@@ -22,11 +22,11 @@ class ExportedValueReference(exportedValue: PSExportedValue) : PsiReferenceBase.
 
     private val candidates: List<PsiNamedElement>
         get() =
-            myElement.module.run {
+            myElement?.module?.run {
                 listOf(
                     *valueDeclarations,
                     *foreignValueDeclarations,
                     *classDeclarations.flatMap { it.classMembers.toList() }.toTypedArray()
                 )
-            }
+            } ?: emptyList()
 }

--- a/src/main/java/org/purescript/psi/exports/PSExportedItem.kt
+++ b/src/main/java/org/purescript/psi/exports/PSExportedItem.kt
@@ -60,7 +60,7 @@ class PSExportedModule(node: ASTNode) : PSExportedItem(node) {
 
     val importDeclaration: PSImportDeclarationImpl?
         get() =
-            module.importDeclarations.singleOrNull {
+            module?.importDeclarations?.singleOrNull {
                 it.name == properName.name
             }
 

--- a/src/main/java/org/purescript/psi/typeconstructor/TypeConstructorReference.kt
+++ b/src/main/java/org/purescript/psi/typeconstructor/TypeConstructorReference.kt
@@ -22,8 +22,8 @@ class TypeConstructorReference(typeConstructor: PSTypeConstructor) :
      *  Add support for type declarations
      */
     private val candidates: List<PSPsiElement>
-        get() = myElement.module.run {
+        get() = myElement.module?.run {
             dataDeclarations.toList() + newTypeDeclarations.toList() +
                 importDeclarations.flatMap { it.importedDataDeclarations + it.importedNewTypeDeclarations }
-        }
+        } ?: emptyList()
 }

--- a/src/main/java/org/purescript/psi/var/ImportedValueReference.kt
+++ b/src/main/java/org/purescript/psi/var/ImportedValueReference.kt
@@ -14,6 +14,7 @@ class ImportedValueReference(element: PSVar) : PsiReferenceBase.Poly<PSVar>(
 
     override fun getVariants(): Array<PsiNamedElement> {
         val currentModule = myElement.module
+            ?: return emptyArray()
         return currentModule.importDeclarations
             .flatMap { it.importedValueDeclarations }
             .toTypedArray()

--- a/src/main/java/org/purescript/psi/var/LocalForeignValueReference.kt
+++ b/src/main/java/org/purescript/psi/var/LocalForeignValueReference.kt
@@ -11,7 +11,8 @@ class LocalForeignValueReference(element: PSVar) : PsiReferenceBase<PSVar>(
 ) {
 
     override fun getVariants(): Array<PSForeignValueDeclaration> {
-        return myElement.module.foreignValueDeclarations
+        return myElement.module?.foreignValueDeclarations
+            ?: emptyArray()
     }
 
     override fun resolve(): PSForeignValueDeclaration? {

--- a/src/main/java/org/purescript/psi/var/LocalValueReference.kt
+++ b/src/main/java/org/purescript/psi/var/LocalValueReference.kt
@@ -14,6 +14,7 @@ class LocalValueReference(element: PSVar) : PsiReferenceBase.Poly<PSVar>(
 
     override fun getVariants(): Array<PsiNamedElement> {
         val currentModule = myElement.module
+            ?: return emptyArray()
         return currentModule.valueDeclarations.toList().toTypedArray()
     }
 

--- a/src/test/java/org/purescript/accessors.kt
+++ b/src/test/java/org/purescript/accessors.kt
@@ -12,17 +12,14 @@ import org.purescript.psi.classes.PSClassDeclaration
 import org.purescript.psi.classes.PSClassMember
 import org.purescript.psi.data.PSDataConstructor
 import org.purescript.psi.data.PSDataDeclaration
-import org.purescript.psi.exports.PSExportedData
-import org.purescript.psi.exports.PSExportedDataMember
-import org.purescript.psi.exports.PSExportedItem
-import org.purescript.psi.exports.PSExportedValue
+import org.purescript.psi.exports.*
 import org.purescript.psi.imports.*
 import org.purescript.psi.typeconstructor.PSTypeConstructor
 import org.purescript.psi.typesynonym.PSTypeSynonymDeclaration
 
 
 fun PsiFile.getModule(): PSModule =
-    (this as PSFile).module
+    (this as PSFile).module!!
 
 fun PsiFile.getDataDeclaration(): PSDataDeclaration =
     getModule().dataDeclarations.single()
@@ -72,14 +69,20 @@ fun PsiFile.getImportedData(): PSImportedData =
 fun PsiFile.getImportedValue(): PSImportedValue =
     getImportedItem() as PSImportedValue
 
+fun PsiFile.getExportedItems(): Array<PSExportedItem> =
+    getModule().exportList!!.exportedItems
+
 fun PsiFile.getExportedItem(): PSExportedItem =
-    getModule().exportList!!.exportedItems.single()
+    getExportedItems().single()
 
 fun PsiFile.getExportedData(): PSExportedData =
     getExportedItem() as PSExportedData
 
 fun PsiFile.getExportedValue(): PSExportedValue =
     getExportedItem() as PSExportedValue
+
+fun PsiFile.getExportedModule(): PSExportedModule =
+    getExportedItem() as PSExportedModule
 
 fun PsiFile.getExportedDataMember(): PSExportedDataMember =
     getExportedData().dataMemberList!!.dataMembers.single()

--- a/src/test/java/org/purescript/psi/ModuleReferenceTest.kt
+++ b/src/test/java/org/purescript/psi/ModuleReferenceTest.kt
@@ -1,17 +1,10 @@
 package org.purescript.psi
 
-import com.intellij.psi.PsiFile
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import org.purescript.file.PSFile
-import org.purescript.psi.imports.PSImportDeclarationImpl
+import org.purescript.getImportDeclaration
+import org.purescript.getModule
 
 class ModuleReferenceTest : BasePlatformTestCase() {
-
-    private fun PsiFile.getModule(): PSModule =
-        (this as PSFile).module
-
-    private fun PsiFile.getImportDeclarations(): Array<PSImportDeclarationImpl> =
-        getModule().importDeclarations
 
     fun `test resolves module`() {
         val module = myFixture.configureByText(
@@ -20,15 +13,15 @@ class ModuleReferenceTest : BasePlatformTestCase() {
                 module Bar where
             """.trimIndent()
         ).getModule()
-        val reference = myFixture.configureByText(
+        val importDeclaration = myFixture.configureByText(
             "Foo.purs",
             """
                 module Foo where
                 import Bar
             """.trimIndent()
-        ).getImportDeclarations().single().reference
+        ).getImportDeclaration()
 
-        assertEquals(module, reference.resolve())
+        assertEquals(module, importDeclaration.reference.resolve())
     }
 
     fun `test resolves aliased module`() {
@@ -38,15 +31,15 @@ class ModuleReferenceTest : BasePlatformTestCase() {
                 module Bar where
             """.trimIndent()
         ).getModule()
-        val reference = myFixture.configureByText(
+        val importDeclaration = myFixture.configureByText(
             "Foo.purs",
             """
                 module Foo where
                 import Bar as B
             """.trimIndent()
-        ).getImportDeclarations().single().reference
+        ).getImportDeclaration()
 
-        assertEquals(module, reference.resolve())
+        assertEquals(module, importDeclaration.reference.resolve())
     }
 
     fun `test finds usage of module with doc comments`() {
@@ -63,8 +56,7 @@ class ModuleReferenceTest : BasePlatformTestCase() {
                 module Foo where
                 import Bar
             """.trimIndent()
-        ).getImportDeclarations().single()
-
+        ).getImportDeclaration()
         val usageInfo = myFixture.testFindUsages("Bar.purs").single()
 
         assertEquals(importDeclaration, usageInfo.element)

--- a/src/test/java/org/purescript/psi/PSModuleTest.kt
+++ b/src/test/java/org/purescript/psi/PSModuleTest.kt
@@ -13,54 +13,54 @@ class PSModuleTest : BasePlatformTestCase() {
 
 
     fun `test one word name`() {
-        val file = myFixture.addFileToProject(
+        val module = myFixture.addFileToProject(
             "Main.purs",
             """module Main where"""
-        ) as PSFile
-        assertEquals("Main", file.module.name)
+        ).getModule()
+        assertEquals("Main", module.name)
     }
 
     fun `test two word name`() {
-        val file = myFixture.addFileToProject(
+        val module = myFixture.addFileToProject(
             "Main.purs",
             """module My.Main where"""
-        ) as PSFile
-        assertEquals("My.Main", file.module.name)
+        ).getModule()
+        assertEquals("My.Main", module.name)
     }
 
     fun `test be able to find no exported names`() {
-        val file = myFixture.addFileToProject(
+        val module = myFixture.addFileToProject(
             "Main.purs",
             """module My.Main where"""
-        ) as PSFile
-        assertEquals(0, file.module.exportedNames.size)
+        ).getModule()
+        assertEquals(0, module.exportedNames.size)
     }
 
     fun `test be able to find one exported names`() {
-        val file = myFixture.addFileToProject(
+        val module = myFixture.addFileToProject(
             "Main.purs",
             """
             module My.Main (x) where
             x  = 1
             """.trimIndent()
-        ) as PSFile
-        assertEquals(1, file.module.exportedNames.size)
+        ).getModule()
+        assertEquals(1, module.exportedNames.size)
     }
 
     fun `test be able to find two exported names`() {
-        val file = myFixture.addFileToProject(
+        val module = myFixture.addFileToProject(
             "Main.purs",
             """module My.Main (x, y) where
                x = 1
                y = 2
             """.trimIndent()
-        ) as PSFile
-        assertEquals(2, file.module.exportedNames.size)
-        assertContainsElements(file.module.exportedNames, "x", "y")
+        ).getModule()
+        assertEquals(2, module.exportedNames.size)
+        assertContainsElements(module.exportedNames, "x", "y")
     }
 
     fun `test do not count module export as exported names`() {
-        val file = myFixture.addFileToProject(
+        val module = myFixture.addFileToProject(
             "Main.purs",
             """module My.Main (x, module Y) where
                
@@ -68,12 +68,12 @@ class PSModuleTest : BasePlatformTestCase() {
                
                x = 1
             """.trimIndent()
-        ) as PSFile
-        assertEquals(1, file.module.exportedNames.size)
+        ).getModule()
+        assertEquals(1, module.exportedNames.size)
     }
 
     fun `test knows what modules get reexported`() {
-        val file = myFixture.addFileToProject(
+        val module = myFixture.addFileToProject(
             "Main.purs",
             """module My.Main (x, module Y) where
                
@@ -81,70 +81,70 @@ class PSModuleTest : BasePlatformTestCase() {
                
                x = 1
             """.trimIndent()
-        ) as PSFile
-        assertEquals(1, file.module.reexportedModuleNames.size)
-        assertContainsElements(file.module.reexportedModuleNames, "Y")
+        ).getModule()
+        assertEquals(1, module.reexportedModuleNames.size)
+        assertContainsElements(module.reexportedModuleNames, "Y")
     }
 
     fun `test finds doc comment`() {
-        val file = myFixture.addFileToProject(
+        val module = myFixture.addFileToProject(
             "Main.purs",
             """-- | This is
                -- | main
                module My.Main (x, y) where
             """.trimIndent()
-        ) as PSFile
+        ).getModule()
 
-        assertEquals("-- | This is", file.module.docComments[0].text)
-        assertEquals("-- | main", file.module.docComments[1].text)
+        assertEquals("-- | This is", module.docComments[0].text)
+        assertEquals("-- | main", module.docComments[1].text)
     }
 
     fun `test finds data declarations`() {
-        val file = myFixture.addFileToProject(
+        val module = myFixture.addFileToProject(
             "Main.purs",
             """ module Main where
                 data Foo = Bar
                 data Qux a b = Baz (a -> b)
             """.trimIndent()
-        ) as PSFile
-        assertSize(2, file.module.dataDeclarations)
+        ).getModule()
+        assertSize(2, module.dataDeclarations)
     }
 
     fun `test finds foreign value declarations`() {
-        val file = myFixture.addFileToProject(
+        val module = myFixture.addFileToProject(
             "Main.purs",
             """ module Main (split) where
                 
                 -- | Returns the substrings of the second string separated
                 foreign import split :: Pattern -> String -> Array String
             """.trimIndent()
-        ) as PSFile
-        TestCase.assertEquals(1, file.module.foreignValueDeclarations.size)
+        ).getModule()
+        TestCase.assertEquals(1, module.foreignValueDeclarations.size)
     }
 
     fun `test exported value declarations (exports all)`() {
-        val file = myFixture.configureByText(
+        val module = myFixture.configureByText(
             "Foo.purs",
             """
                 module Foo where
                 a = 1
                 b = 2
             """.trimIndent()
-        ) as PSFile
-        val actualExportedValueDeclarationNames = file.module.exportedValueDeclarations.map { it.name }
+        ).getModule()
+        val actualExportedValueDeclarationNames = module.exportedValueDeclarations.map { it.name }
         assertContainsElements(actualExportedValueDeclarationNames, "a", "b")
     }
 
     fun `test exported value declarations (exports some)`() {
-        val file = myFixture.configureByText(
+        val module = myFixture.configureByText(
             "Foo.purs",
             """
                 module Foo (b) where
                 a = 1
                 b = 2
             """.trimIndent()
-        ) as PSFile
-        val actualExportedValueDeclarationNames = file.module.exportedValueDeclarations.map { it.name }
+        ).getModule()
+        val actualExportedValueDeclarationNames = module.exportedValueDeclarations.map { it.name }
         assertSameElements(actualExportedValueDeclarationNames, "b")
     }
 
@@ -157,14 +157,14 @@ class PSModuleTest : BasePlatformTestCase() {
                 b = 2
             """.trimIndent()
         )
-        val file = myFixture.configureByText(
+        val module = myFixture.configureByText(
             "Foo.purs",
             """
                 module Foo (module Bar) where
                 import Bar
             """.trimIndent()
-        ) as PSFile
-        val actualExportedValueDeclarationNames = file.module.exportedValueDeclarations.map { it.name }
+        ).getModule()
+        val actualExportedValueDeclarationNames = module.exportedValueDeclarations.map { it.name }
         assertSameElements(actualExportedValueDeclarationNames, "a", "b")
     }
 
@@ -178,14 +178,14 @@ class PSModuleTest : BasePlatformTestCase() {
                 c = 3
             """.trimIndent()
         )
-        val file = myFixture.configureByText(
+        val module = myFixture.configureByText(
             "Foo.purs",
             """
                 module Foo (module Bar) where
                 import Bar (a)
             """.trimIndent()
-        ) as PSFile
-        val actualExportedValueDeclarationNames = file.module.exportedValueDeclarations.map { it.name }
+        ).getModule()
+        val actualExportedValueDeclarationNames = module.exportedValueDeclarations.map { it.name }
         assertSameElements(actualExportedValueDeclarationNames, "a")
     }
 
@@ -199,14 +199,14 @@ class PSModuleTest : BasePlatformTestCase() {
                 c = 3
             """.trimIndent()
         )
-        val file = myFixture.configureByText(
+        val module = myFixture.configureByText(
             "Foo.purs",
             """
                 module Foo (module Bar) where
                 import Bar hiding (a)
             """.trimIndent()
-        ) as PSFile
-        val actualExportedValueDeclarationNames = file.module.exportedValueDeclarations.map { it.name }
+        ).getModule()
+        val actualExportedValueDeclarationNames = module.exportedValueDeclarations.map { it.name }
         assertSameElements(actualExportedValueDeclarationNames, "b")
     }
 
@@ -227,14 +227,14 @@ class PSModuleTest : BasePlatformTestCase() {
                 import Qux
             """.trimIndent()
         )
-        val file = myFixture.configureByText(
+        val module = myFixture.configureByText(
             "Foo.purs",
             """
                 module Foo (module Bar) where
                 import Bar
             """.trimIndent()
-        ) as PSFile
-        val actualExportedValueDeclarationNames = file.module.exportedValueDeclarations.map { it.name }
+        ).getModule()
+        val actualExportedValueDeclarationNames = module.exportedValueDeclarations.map { it.name }
         assertSameElements(actualExportedValueDeclarationNames, "a", "b", "c")
     }
 
@@ -247,8 +247,8 @@ class PSModuleTest : BasePlatformTestCase() {
                 b = 2
                 c = 3
             """.trimIndent()
-        ) as PSFile
-        val quxExportedValueDeclarationNames = qux.module.exportedValueDeclarations.map { it.name }
+        ).getModule()
+        val quxExportedValueDeclarationNames = qux.exportedValueDeclarations.map { it.name }
         assertSameElements(quxExportedValueDeclarationNames, "a", "b")
 
         val bar = myFixture.configureByText(
@@ -259,8 +259,8 @@ class PSModuleTest : BasePlatformTestCase() {
                 d = 4
                 e = 5
             """.trimIndent()
-        ) as PSFile
-        val barExportedValueDeclarationNames = bar.module.exportedValueDeclarations.map { it.name }
+        ).getModule()
+        val barExportedValueDeclarationNames = bar.exportedValueDeclarations.map { it.name }
         assertSameElements(barExportedValueDeclarationNames, "a", "d")
 
         val foo = myFixture.configureByText(
@@ -271,8 +271,8 @@ class PSModuleTest : BasePlatformTestCase() {
                 f = 6
                 g = 7
             """.trimIndent()
-        ) as PSFile
-        val fooExportedValueDeclarationNames = foo.module.exportedValueDeclarations.map { it.name }
+        ).getModule()
+        val fooExportedValueDeclarationNames = foo.exportedValueDeclarations.map { it.name }
         assertSameElements(fooExportedValueDeclarationNames, "a", "g")
     }
 

--- a/src/test/java/org/purescript/psi/PSValueDeclarationTest.kt
+++ b/src/test/java/org/purescript/psi/PSValueDeclarationTest.kt
@@ -1,12 +1,12 @@
 package org.purescript.psi
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import junit.framework.TestCase
-import org.purescript.file.PSFile
+import org.purescript.getModule
+import org.purescript.getValueDeclaration
 
 class PSValueDeclarationTest : BasePlatformTestCase() {
     fun `test finds doc comment`() {
-        val file = myFixture.addFileToProject(
+        val valueDeclaration = myFixture.addFileToProject(
             "Main.purs",
             """-- | This is
                -- | main module
@@ -15,13 +15,11 @@ class PSValueDeclarationTest : BasePlatformTestCase() {
                -- | main
                main = 1
             """.trimIndent()
-        ) as PSFile
+        ).getValueDeclaration()
+        val docComments = valueDeclaration.docComments
 
-        val main =
-            file.module.valueDeclarations.find { it.name == "main"} !!
-        val docComments = main.docComments
-        TestCase.assertEquals(2, docComments.size)
-        TestCase.assertEquals("-- | This is",  docComments[0].text)
-        TestCase.assertEquals("-- | main",  docComments[1].text)
+        assertEquals(2, docComments.size)
+        assertEquals("-- | This is", docComments[0].text)
+        assertEquals("-- | main", docComments[1].text)
     }
 }

--- a/src/test/java/org/purescript/psi/exports/ExportedModuleReferenceTest.kt
+++ b/src/test/java/org/purescript/psi/exports/ExportedModuleReferenceTest.kt
@@ -1,18 +1,11 @@
 package org.purescript.psi.exports
 
-import com.intellij.psi.PsiFile
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import junit.framework.TestCase
-import org.purescript.file.PSFile
-import org.purescript.psi.PSModule
+import org.purescript.getExportedModule
+import org.purescript.getImportDeclaration
+import org.purescript.getModule
 
 class ExportedModuleReferenceTest : BasePlatformTestCase() {
-
-    private fun PsiFile.getModule(): PSModule =
-        (this as PSFile).module
-
-    private fun PsiFile.getExportedModule(): PSExportedModule =
-        getModule().exportList!!.exportedItems.single() as PSExportedModule
 
     fun `test completes imported modules`() {
         myFixture.configureByText(
@@ -53,7 +46,7 @@ class ExportedModuleReferenceTest : BasePlatformTestCase() {
             """.trimIndent()
         ).getModule()
 
-        TestCase.assertTrue(exportedModule.reference.isReferenceTo(module))
+        assertTrue(exportedModule.reference.isReferenceTo(module))
     }
 
     fun `test aliased exported module resolves to import declaration`() {
@@ -65,9 +58,9 @@ class ExportedModuleReferenceTest : BasePlatformTestCase() {
             """.trimIndent()
         )
         val exportedModule = file.getExportedModule()
-        val importAlias = file.getModule().importDeclarations.single().importAlias!!
+        val importAlias = file.getImportDeclaration().importAlias!!
 
-        TestCase.assertTrue(exportedModule.reference.isReferenceTo(importAlias))
+        assertTrue(exportedModule.reference.isReferenceTo(importAlias))
     }
 
     fun `test does not resolve to module if not imported`() {
@@ -84,7 +77,7 @@ class ExportedModuleReferenceTest : BasePlatformTestCase() {
             """.trimIndent()
         ).getModule()
 
-        TestCase.assertFalse(exportedModule.reference.isReferenceTo(module))
+        assertFalse(exportedModule.reference.isReferenceTo(module))
     }
 
     fun `test does not resolve to aliased module using wrong name`() {
@@ -102,7 +95,7 @@ class ExportedModuleReferenceTest : BasePlatformTestCase() {
             """.trimIndent()
         ).getModule()
 
-        TestCase.assertFalse(exportedModule.reference.isReferenceTo(module))
+        assertFalse(exportedModule.reference.isReferenceTo(module))
     }
 
     fun `test does not resolve to module if it does not exist`() {
@@ -113,7 +106,7 @@ class ExportedModuleReferenceTest : BasePlatformTestCase() {
             """.trimIndent()
         ).getExportedModule()
 
-        TestCase.assertNull(exportedModule.reference.resolve())
+        assertNull(exportedModule.reference.resolve())
     }
 
     fun `test finds usage of import alias`() {
@@ -125,9 +118,9 @@ class ExportedModuleReferenceTest : BasePlatformTestCase() {
             """.trimIndent()
         )
         val exportedModule = file.getExportedModule()
-        val importAlias = file.getModule().importDeclarations.single().importAlias!!
-        val usage = myFixture.findUsages(importAlias).single().element!!
+        val importAlias = file.getImportDeclaration().importAlias!!
+        val usageInfo = myFixture.findUsages(importAlias).single()
 
-        TestCase.assertEquals(exportedModule, usage)
+        assertEquals(exportedModule, usageInfo.element)
     }
 }

--- a/src/test/java/org/purescript/psi/exports/ExportedValueReferenceTest.kt
+++ b/src/test/java/org/purescript/psi/exports/ExportedValueReferenceTest.kt
@@ -1,37 +1,30 @@
 package org.purescript.psi.exports
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import org.purescript.file.PSFile
-import org.purescript.getClassMember
-import org.purescript.getExportedValue
+import org.purescript.*
 
 class ExportedValueReferenceTest : BasePlatformTestCase() {
 
     fun `test resolves to declared value`() {
-        val file = myFixture.addFileToProject(
+        myFixture.addFileToProject(
             "Main.purs",
             """module Main (foo) where
                foo = 3
             """.trimIndent()
-        ) as PSFile
-        val exportedValue = file.module.exportList!!.exportedItems.single() as PSExportedValue
-        val declaredValue = file.module.valueDeclarations.single()
-        val resolvedReference = exportedValue.reference.resolve()
-
-        assertEquals(declaredValue, resolvedReference)
+        ).run {
+            assertEquals(getValueDeclaration(), getExportedValue().reference.resolve())
+        }
     }
 
     fun `test resolve fails when no declared value`() {
-        val file = myFixture.addFileToProject(
+        val exportedValue = myFixture.addFileToProject(
             "Main.purs",
             """module Main (foo) where
                bar = 3
             """.trimIndent()
-        ) as PSFile
-        val exportedValue = file.module.exportList!!.exportedItems.single() as PSExportedValue
-        val resolvedReference = exportedValue.reference.resolve()
+        ).getExportedValue()
 
-        assertNull(resolvedReference)
+        assertNull(exportedValue.reference.resolve())
     }
 
     fun `test resolves to all declared values`() {
@@ -42,30 +35,24 @@ class ExportedValueReferenceTest : BasePlatformTestCase() {
                foo false = 4
                bar false = 4
             """.trimIndent()
-        ) as PSFile
-        val exportedValue = file.module.exportList!!.exportedItems.single() as PSExportedValue
-        val valueDeclarations = file.module.valueDeclarations.toList()
-        val firstFooDeclaration = valueDeclarations[0]
-        val secondFooDeclaration = valueDeclarations[1]
-        val barDeclaration = valueDeclarations[2]
+        )
+        val exportedValue = file.getExportedValue()
+        val valueDeclarations = file.getValueDeclarations()
 
-        assertTrue(exportedValue.reference.isReferenceTo(firstFooDeclaration))
-        assertTrue(exportedValue.reference.isReferenceTo(secondFooDeclaration))
-        assertFalse(exportedValue.reference.isReferenceTo(barDeclaration))
+        assertTrue(exportedValue.reference.isReferenceTo(valueDeclarations[0]))
+        assertTrue(exportedValue.reference.isReferenceTo(valueDeclarations[1]))
+        assertFalse(exportedValue.reference.isReferenceTo(valueDeclarations[2]))
     }
 
     fun `test resolves to foreign values`() {
-        val file = myFixture.addFileToProject(
+        myFixture.addFileToProject(
             "Main.purs",
             """module Main (foo) where
                foreign import foo :: Int
             """.trimIndent()
-        ) as PSFile
-        val module = file.module
-        val exportedValue = module.exportList!!.exportedItems.single() as PSExportedValue
-        val foreignValueDeclaration = module.foreignValueDeclarations.single()
-
-        assertTrue(exportedValue.reference.isReferenceTo(foreignValueDeclaration))
+        ).run {
+            assertEquals(getForeignValueDeclaration(), getExportedValue().reference.resolve())
+        }
     }
 
     fun `test completes exported values`() {
@@ -77,32 +64,34 @@ class ExportedValueReferenceTest : BasePlatformTestCase() {
                 f2 = 2
                 bar = 3
             """.trimIndent()
-        ) as PSFile
+        )
         myFixture.testCompletionVariants("Main.purs", "f1", "f2")
     }
 
     fun `test finds usage of declared value`() {
-        val file = myFixture.configureByText(
+        val exportedValue = myFixture.configureByText(
             "Foo.purs",
             """
                 module Foo (foo) where
                 <caret>foo = 3
             """.trimIndent()
-        ) as PSFile
-        val exportedValue = file.module.exportList!!.exportedItems.single()
-        assertEquals(exportedValue, myFixture.testFindUsages("Foo.purs").single().element)
+        ).getExportedValue()
+        val usageInfo = myFixture.testFindUsages("Foo.purs").single()
+
+        assertEquals(exportedValue, usageInfo.element)
     }
 
     fun `test finds usage of foreign value`() {
-        val file = myFixture.configureByText(
+        val exportedValue = myFixture.configureByText(
             "Foo.purs",
             """
                 module Foo (foo) where
                 foreign import <caret>foo :: Int
             """.trimIndent()
-        ) as PSFile
-        val exportedValue = file.module.exportList!!.exportedItems.single()
-        assertEquals(exportedValue, myFixture.testFindUsages("Foo.purs").single().element)
+        ).getExportedValue()
+        val usageInfo = myFixture.testFindUsages("Foo.purs").single()
+
+        assertEquals(exportedValue, usageInfo.element)
     }
 
     fun `test does not find usage if caret is misplaced`() {
@@ -156,16 +145,19 @@ class ExportedValueReferenceTest : BasePlatformTestCase() {
     }
 
     fun `test finds usages class members`() {
-        myFixture.configureByText(
+        val file = myFixture.configureByText(
             "Foo.purs",
             """
                 module Foo (bar) where
                 class Bar where
                     bar :: Int
             """.trimIndent()
-        ).run {
-            val usageInfo = myFixture.findUsages(getClassMember()).single()
-            assertEquals(getExportedValue(), usageInfo.element)
+        )
+        val exportedValue = file.getExportedValue()
+        val usageInfo = myFixture.findUsages(file.getClassMember()).single()
+
+        run {
+            assertEquals(exportedValue, usageInfo.element)
         }
     }
 }

--- a/src/test/java/org/purescript/psi/exports/PSExportListTest.kt
+++ b/src/test/java/org/purescript/psi/exports/PSExportListTest.kt
@@ -1,24 +1,19 @@
 package org.purescript.psi.exports
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import junit.framework.TestCase
-import org.purescript.file.PSFile
-import org.purescript.psi.exports.PSExportedClass
-import org.purescript.psi.exports.PSExportedKind
-import org.purescript.psi.exports.PSExportedValue
+import org.purescript.getExportedItems
 
 class PSExportListTest : BasePlatformTestCase() {
 
     fun `test export list contains exported items`() {
-        val file = myFixture.addFileToProject(
+        val exportedItems = myFixture.addFileToProject(
             "Main.purs",
             """module Main (foo, kind Boolean, class Eq) where"""
-        ) as PSFile
-        val exportedItems = file.module.exportList!!.exportedItems
+        ).getExportedItems()
 
-        TestCase.assertEquals(3, exportedItems.size)
-        TestCase.assertTrue(exportedItems[0] is PSExportedValue)
-        TestCase.assertTrue(exportedItems[1] is PSExportedKind)
-        TestCase.assertTrue(exportedItems[2] is PSExportedClass)
+        assertEquals(3, exportedItems.size)
+        assertTrue(exportedItems[0] is PSExportedValue)
+        assertTrue(exportedItems[1] is PSExportedKind)
+        assertTrue(exportedItems[2] is PSExportedClass)
     }
 }

--- a/src/test/java/org/purescript/psi/exports/PSExportedItemTest.kt
+++ b/src/test/java/org/purescript/psi/exports/PSExportedItemTest.kt
@@ -1,124 +1,114 @@
 package org.purescript.psi.exports
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import junit.framework.TestCase
-import org.purescript.file.PSFile
+import org.purescript.getExportedItem
 
 class PSExportedItemTest : BasePlatformTestCase() {
 
     fun `test parses exported class`() {
-        val file = myFixture.addFileToProject(
+        val exportedItem = myFixture.addFileToProject(
             "Main.purs",
             """module Main (class Foo) where"""
-        ) as PSFile
-        val exportedItem = file.module.exportList!!.exportedItems.single()
+        ).getExportedItem()
 
-        TestCase.assertTrue(exportedItem is PSExportedClass)
-        TestCase.assertEquals("Foo", exportedItem.name)
+        assertTrue(exportedItem is PSExportedClass)
+        assertEquals("Foo", exportedItem.name)
     }
 
     fun `test parses exported data`() {
-        val file = myFixture.addFileToProject(
+        val exportedItem = myFixture.addFileToProject(
             "Main.purs",
             """module Main (Foo) where"""
-        ) as PSFile
-        val exportedItem = file.module.exportList!!.exportedItems.single()
+        ).getExportedItem()
 
-        TestCase.assertTrue(exportedItem is PSExportedData)
+        assertTrue(exportedItem is PSExportedData)
         val exportedData = exportedItem as PSExportedData
 
-        TestCase.assertEquals("Foo", exportedItem.name)
-        TestCase.assertNull(exportedData.dataMemberList)
+        assertEquals("Foo", exportedItem.name)
+        assertNull(exportedData.dataMemberList)
     }
 
     fun `test parses exported data with all members`() {
-        val file = myFixture.addFileToProject(
+        val exportedItem = myFixture.addFileToProject(
             "Main.purs",
             """module Main (Foo(..)) where"""
-        ) as PSFile
-        val exportedItem = file.module.exportList!!.exportedItems.single()
+        ).getExportedItem()
 
-        TestCase.assertTrue(exportedItem is PSExportedData)
+        assertTrue(exportedItem is PSExportedData)
         val exportedData = exportedItem as PSExportedData
 
-        TestCase.assertEquals("Foo", exportedItem.name)
+        assertEquals("Foo", exportedItem.name)
         val dataMemberList = exportedData.dataMemberList
 
-        TestCase.assertNotNull(exportedData.dataMemberList)
-        TestCase.assertNotNull(dataMemberList!!.doubleDot)
-        TestCase.assertTrue(dataMemberList.dataMembers.isEmpty())
+        assertNotNull(exportedData.dataMemberList)
+        assertNotNull(dataMemberList!!.doubleDot)
+        assertTrue(dataMemberList.dataMembers.isEmpty())
     }
 
     fun `test parses exported data with some members`() {
-        val file = myFixture.addFileToProject(
+        val exportedItem = myFixture.addFileToProject(
             "Main.purs",
             """module Main (Foo(Bar, Baz)) where"""
-        ) as PSFile
-        val exportedItem = file.module.exportList!!.exportedItems.single()
+        ).getExportedItem()
 
-        TestCase.assertTrue(exportedItem is PSExportedData)
+        assertTrue(exportedItem is PSExportedData)
         val exportedData = exportedItem as PSExportedData
 
-        TestCase.assertEquals("Foo", exportedItem.name)
+        assertEquals("Foo", exportedItem.name)
         val dataMemberList = exportedData.dataMemberList
 
-        TestCase.assertNotNull(exportedData.dataMemberList)
-        TestCase.assertNull(dataMemberList!!.doubleDot)
-        TestCase.assertEquals(2, dataMemberList.dataMembers.size)
+        assertNotNull(exportedData.dataMemberList)
+        assertNull(dataMemberList!!.doubleDot)
+        assertEquals(2, dataMemberList.dataMembers.size)
     }
 
     fun `test parses exported kind`() {
-        val file = myFixture.addFileToProject(
+        val exportedItem = myFixture.addFileToProject(
             "Main.purs",
             """module Main (kind Foo) where"""
-        ) as PSFile
-        val exportedItem = file.module.exportList!!.exportedItems.single()
+        ).getExportedItem()
 
-        TestCase.assertTrue(exportedItem is PSExportedKind)
-        TestCase.assertEquals("Foo", exportedItem.name)
+        assertTrue(exportedItem is PSExportedKind)
+        assertEquals("Foo", exportedItem.name)
     }
 
     fun `test parses exported module`() {
-        val file = myFixture.addFileToProject(
+        val exportedItem = myFixture.addFileToProject(
             "Main.purs",
             """module Main (module Foo) where"""
-        ) as PSFile
-        val exportedItem = file.module.exportList!!.exportedItems.single()
+        ).getExportedItem()
 
-        TestCase.assertTrue(exportedItem is PSExportedModule)
-        TestCase.assertEquals("Foo", exportedItem.name)
+        assertTrue(exportedItem is PSExportedModule)
+        assertEquals("Foo", exportedItem.name)
     }
 
     fun `test parses exported operator`() {
-        val file = myFixture.addFileToProject(
+        val exportedItem = myFixture.addFileToProject(
             "Main.purs",
             """module Main ((<~>)) where"""
-        ) as PSFile
-        val exportedItem = file.module.exportList!!.exportedItems.single()
+        ).getExportedItem()
 
-        TestCase.assertTrue(exportedItem is PSExportedOperator)
-        TestCase.assertEquals("<~>", exportedItem.name)
+        assertTrue(exportedItem is PSExportedOperator)
+        assertEquals("<~>", exportedItem.name)
     }
 
     fun `test parses exported type`() {
-        val file = myFixture.addFileToProject(
+        val exportedItem = myFixture.addFileToProject(
             "Main.purs",
             """module Main (type (<<=>>)) where"""
-        ) as PSFile
-        val exportedItem = file.module.exportList!!.exportedItems.single()
+        ).getExportedItem()
 
-        TestCase.assertTrue(exportedItem is PSExportedType)
-        TestCase.assertEquals("<<=>>", exportedItem.name)
+        assertTrue(exportedItem is PSExportedType)
+        assertEquals("<<=>>", exportedItem.name)
     }
 
     fun `test parses exported value`() {
-        val file = myFixture.addFileToProject(
+        val exportedItem = myFixture.addFileToProject(
             "Main.purs",
             """module Main (foo) where"""
-        ) as PSFile
-        val exportedItem = file.module.exportList!!.exportedItems.single()
+        ).getExportedItem()
 
-        TestCase.assertTrue(exportedItem is PSExportedValue)
-        TestCase.assertEquals("foo", exportedItem.name)
+        assertTrue(exportedItem is PSExportedValue)
+        assertEquals("foo", exportedItem.name)
     }
 }

--- a/src/test/java/org/purescript/psi/imports/PSImportDeclarationImplTest.kt
+++ b/src/test/java/org/purescript/psi/imports/PSImportDeclarationImplTest.kt
@@ -2,27 +2,27 @@ package org.purescript.psi.imports
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import junit.framework.TestCase
-import org.purescript.file.PSFile
 import org.purescript.getImportDeclaration
 import org.purescript.getImportDeclarations
+import org.purescript.getModule
 
 class PSImportDeclarationImplTest : BasePlatformTestCase() {
 
     fun `test resolve to module in root directory`() {
-        val mainFile = myFixture.addFileToProject(
+        val module = myFixture.addFileToProject(
             "Main.purs",
             """
             module Main where
             import Foo
             """.trimIndent()
-        ) as PSFile
+        ).getModule()
         myFixture.addFileToProject(
             "Foo.purs",
             """
             module Foo where
             """.trimIndent()
         )
-        val psImportDeclaration = mainFile.module.getImportDeclarationByName("Foo")!!
+        val psImportDeclaration = module.getImportDeclarationByName("Foo")!!
 
         val psModule = psImportDeclaration.reference.resolve()!!
 
@@ -30,15 +30,15 @@ class PSImportDeclarationImplTest : BasePlatformTestCase() {
     }
 
     fun `test dont crash if module not found`() {
-        val mainFile = myFixture.addFileToProject(
+        val module = myFixture.addFileToProject(
             "Main.purs",
             """
             module Main where
             import Foo
             """.trimIndent()
-        ) as PSFile
+        ).getModule()
 
-        val psImportDeclaration = mainFile.module.getImportDeclarationByName("Foo")!!
+        val psImportDeclaration = module.getImportDeclarationByName("Foo")!!
 
         val psModule = psImportDeclaration.reference.resolve()
         TestCase.assertNull(psModule)
@@ -46,20 +46,20 @@ class PSImportDeclarationImplTest : BasePlatformTestCase() {
 
 
     fun `test resolve to module in subdirectory`() {
-        val mainFile = myFixture.addFileToProject(
+        val module = myFixture.addFileToProject(
             "Main.purs",
             """
             module Main where
             import Bar.Foo
             """.trimIndent()
-        ) as PSFile
+        ).getModule()
         myFixture.addFileToProject(
             "Bar/Foo.purs",
             """
             module Bar.Foo where
             """.trimIndent()
         )
-        val psImportDeclaration = mainFile.module.getImportDeclarationByName("Bar.Foo")!!
+        val psImportDeclaration = module.getImportDeclarationByName("Bar.Foo")!!
 
         val psModule = psImportDeclaration.reference.resolve()!!
 
@@ -67,13 +67,13 @@ class PSImportDeclarationImplTest : BasePlatformTestCase() {
     }
 
     fun `test resolve to module with correct module name when there is competing files`() {
-        val mainFile = myFixture.addFileToProject(
+        val module = myFixture.addFileToProject(
             "Main.purs",
             """
             module Main where
             import Bar.Foo
             """.trimIndent()
-        ) as PSFile
+        ).getModule()
         myFixture.addFileToProject(
             "Bar/Foo.purs",
             """
@@ -86,7 +86,7 @@ class PSImportDeclarationImplTest : BasePlatformTestCase() {
             module Foo where
             """.trimIndent()
         )
-        val psImportDeclaration = mainFile.module.getImportDeclarationByName("Bar.Foo")!!
+        val psImportDeclaration = module.getImportDeclarationByName("Bar.Foo")!!
 
         val resolve = psImportDeclaration.reference.resolve()
         val psModule = resolve!!
@@ -95,7 +95,7 @@ class PSImportDeclarationImplTest : BasePlatformTestCase() {
     }
 
     fun `test knows about imported names`() {
-        val mainFile = myFixture.addFileToProject(
+        val module = myFixture.addFileToProject(
             "Main.purs",
             """
             module Main where
@@ -104,21 +104,21 @@ class PSImportDeclarationImplTest : BasePlatformTestCase() {
             import Buz (x)
             import Fuz (hiding)
             """.trimIndent()
-        ) as PSFile
+        ).getModule()
 
-        val foo = mainFile.module.getImportDeclarationByName("Foo")!!
+        val foo = module.getImportDeclarationByName("Foo")!!
         assertTrue(foo.isHiding)
         assertContainsElements(foo.namedImports, "x")
 
-        val bar = mainFile.module.getImportDeclarationByName("Bar")!!
+        val bar = module.getImportDeclarationByName("Bar")!!
         assertFalse(bar.isHiding)
         assertDoesntContain(bar.namedImports, "x")
 
-        val buz = mainFile.module.getImportDeclarationByName("Buz")!!
+        val buz = module.getImportDeclarationByName("Buz")!!
         assertFalse(buz.isHiding)
         assertContainsElements(buz.namedImports, "x")
 
-        val fuz = mainFile.module.getImportDeclarationByName("Fuz")!!
+        val fuz = module.getImportDeclarationByName("Fuz")!!
         assertFalse(fuz.isHiding)
         assertContainsElements(fuz.namedImports, "hiding")
     }

--- a/src/test/java/org/purescript/psi/imports/PSImportedClassTest.kt
+++ b/src/test/java/org/purescript/psi/imports/PSImportedClassTest.kt
@@ -1,22 +1,19 @@
 package org.purescript.psi.imports
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import junit.framework.TestCase
-import org.purescript.file.PSFile
+import org.purescript.getImportedClass
 
 
 class PSImportedClassTest : BasePlatformTestCase() {
 
     fun `test imported class has correct name`() {
-        val file = myFixture.configureByText(
+        val importedClass = myFixture.configureByText(
             "Foo.purs",
             """
                 module Foo where
                 import Bar (class Qux)
             """.trimIndent()
-        ) as PSFile
-        val importDecl = file.module.importDeclarations.single()
-        val importedClass = importDecl.importList!!.importedItems.single() as PSImportedClass
-        TestCase.assertEquals("Qux", importedClass.name)
+        ).getImportedClass()
+        assertEquals("Qux", importedClass.name)
     }
 }

--- a/src/test/java/org/purescript/psi/imports/PSImportedDataTest.kt
+++ b/src/test/java/org/purescript/psi/imports/PSImportedDataTest.kt
@@ -1,22 +1,19 @@
 package org.purescript.psi.imports
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import junit.framework.TestCase
-import org.purescript.file.PSFile
+import org.purescript.getImportedData
 
 
 class PSImportedDataTest : BasePlatformTestCase() {
 
     fun `test imported data has correct name`() {
-        val file = myFixture.configureByText(
+        val importedData = myFixture.configureByText(
             "Foo.purs",
             """
                 module Foo where
                 import Bar (Qux)
             """.trimIndent()
-        ) as PSFile
-        val importDecl = file.module.importDeclarations.single()
-        val importedData = importDecl.importList!!.importedItems.single() as PSImportedData
-        TestCase.assertEquals("Qux", importedData.name)
+        ).getImportedData()
+        assertEquals("Qux", importedData.name)
     }
 }

--- a/src/test/java/org/purescript/psi/imports/PSImportedKindTest.kt
+++ b/src/test/java/org/purescript/psi/imports/PSImportedKindTest.kt
@@ -1,22 +1,19 @@
 package org.purescript.psi.imports
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import junit.framework.TestCase
-import org.purescript.file.PSFile
+import org.purescript.getImportedItem
 
 
 class PSImportedKindTest : BasePlatformTestCase() {
 
     fun `test imported kind has correct name`() {
-        val file = myFixture.configureByText(
+        val importedKind = myFixture.configureByText(
             "Foo.purs",
             """
                 module Foo where
                 import Bar (kind Qux)
             """.trimIndent()
-        ) as PSFile
-        val importDecl = file.module.importDeclarations.single()
-        val importedKind = importDecl.importList!!.importedItems.single() as PSImportedKind
-        TestCase.assertEquals("Qux", importedKind.name)
+        ).getImportedItem() as PSImportedKind
+        assertEquals("Qux", importedKind.name)
     }
 }

--- a/src/test/java/org/purescript/psi/imports/PSImportedOperatorTest.kt
+++ b/src/test/java/org/purescript/psi/imports/PSImportedOperatorTest.kt
@@ -1,22 +1,19 @@
 package org.purescript.psi.imports
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import junit.framework.TestCase
-import org.purescript.file.PSFile
+import org.purescript.getImportedItem
 
 
 class PSImportedOperatorTest : BasePlatformTestCase() {
 
     fun `test imported operator has correct name`() {
-        val file = myFixture.configureByText(
+        val importedOperator = myFixture.configureByText(
             "Foo.purs",
             """
                 module Foo where
                 import Bar ((<|~|>))
             """.trimIndent()
-        ) as PSFile
-        val importDecl = file.module.importDeclarations.single()
-        val importedOperator = importDecl.importList!!.importedItems.single() as PSImportedOperator
-        TestCase.assertEquals("<|~|>", importedOperator.name)
+        ).getImportedItem() as PSImportedOperator
+        assertEquals("<|~|>", importedOperator.name)
     }
 }

--- a/src/test/java/org/purescript/psi/imports/PSImportedTypeTest.kt
+++ b/src/test/java/org/purescript/psi/imports/PSImportedTypeTest.kt
@@ -1,22 +1,19 @@
 package org.purescript.psi.imports
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import junit.framework.TestCase
-import org.purescript.file.PSFile
+import org.purescript.getImportedItem
 
 
 class PSImportedTypeTest : BasePlatformTestCase() {
 
     fun `test imported type has correct name`() {
-        val file = myFixture.configureByText(
+        val importedType = myFixture.configureByText(
             "Foo.purs",
             """
                 module Foo where
                 import Bar (type (<~>))
             """.trimIndent()
-        ) as PSFile
-        val importDecl = file.module.importDeclarations.single()
-        val importedType = importDecl.importList!!.importedItems.single() as PSImportedType
-        TestCase.assertEquals("<~>", importedType.name)
+        ).getImportedItem() as PSImportedType
+        assertEquals("<~>", importedType.name)
     }
 }

--- a/src/test/java/org/purescript/psi/imports/PSImportedValeTest.kt
+++ b/src/test/java/org/purescript/psi/imports/PSImportedValeTest.kt
@@ -3,20 +3,19 @@ package org.purescript.psi.imports
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import junit.framework.TestCase
 import org.purescript.file.PSFile
+import org.purescript.getImportedValue
 
 
 class PSImportedValeTest : BasePlatformTestCase() {
 
     fun `test imported value has correct name`() {
-        val file = myFixture.configureByText(
+        val importedValue = myFixture.configureByText(
             "Foo.purs",
             """
                 module Foo where
                 import Bar (qux)
             """.trimIndent()
-        ) as PSFile
-        val importDecl = file.module.importDeclarations.single()
-        val importedValue = importDecl.importList!!.importedItems.single() as PSImportedValue
-        TestCase.assertEquals("qux", importedValue.name)
+        ).getImportedValue()
+        assertEquals("qux", importedValue.name)
     }
 }


### PR DESCRIPTION
This PR makes `PSFile#getModule` return `PSModule?` instead of `PSModule`. The reason is that purescript files with invalid module headers may not get a module element at all, and that causes null pointer exceptions down the line.

This change trickled down in a lot of different places, and I took the opportunity to go through and clean up some of the boilerplate in the tests.