### PR TITLE
Implement renaming for modules

### DIFF
--- a/src/main/java/org/purescript/ide/refactoring/PSNamesValidator.kt
+++ b/src/main/java/org/purescript/ide/refactoring/PSNamesValidator.kt
@@ -1,0 +1,21 @@
+package org.purescript.ide.refactoring
+
+import com.intellij.lang.refactoring.NamesValidator
+import com.intellij.openapi.project.Project
+
+/*
+ * TODO
+ *  This validator is used every time we rename something,
+ *  and I haven't found an easy way to make it know what type
+ *  of element is being renamed. As such, if we want to use this,
+ *  it needs to be super permissive, so I made it accept everything
+ *  for now. It's not ideal, but it's better than only accepting
+ *  Java identifiers.
+ */
+class PSNamesValidator : NamesValidator {
+    override fun isKeyword(name: String, project: Project?): Boolean =
+        false
+
+    override fun isIdentifier(name: String, project: Project?): Boolean =
+        true
+}

--- a/src/main/java/org/purescript/ide/refactoring/PSRefactoringSupportProvider.kt
+++ b/src/main/java/org/purescript/ide/refactoring/PSRefactoringSupportProvider.kt
@@ -1,0 +1,11 @@
+package org.purescript.ide.refactoring
+
+import com.intellij.lang.refactoring.RefactoringSupportProvider
+import com.intellij.psi.PsiElement
+import org.purescript.psi.PSModule
+
+class PSRefactoringSupportProvider : RefactoringSupportProvider() {
+    override fun isMemberInplaceRenameAvailable(element: PsiElement, context: PsiElement?): Boolean {
+        return element is PSModule
+    }
+}

--- a/src/main/java/org/purescript/psi/ModuleReference.kt
+++ b/src/main/java/org/purescript/psi/ModuleReference.kt
@@ -2,12 +2,9 @@ package org.purescript.psi
 
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.PsiReferenceBase
-import org.purescript.PSLanguage
 import org.purescript.file.ModuleNameIndex.Companion.fileContainingModule
 import org.purescript.file.ModuleNameIndex.Companion.getAllModuleNames
-import org.purescript.file.PSFile
 import org.purescript.psi.imports.PSImportDeclarationImpl
 
 class ModuleReference(element: PSImportDeclarationImpl) : PsiReferenceBase<PSImportDeclarationImpl>(
@@ -24,17 +21,12 @@ class ModuleReference(element: PSImportDeclarationImpl) : PsiReferenceBase<PSImp
         return fileContainingModule(element.project, moduleName)?.module
     }
 
-    override fun handleElementRename(newElementName: String): PsiElement? {
-        val psiFileFactory = PsiFileFactory.getInstance(element.project)
-        val file = psiFileFactory.createFileFromText(
-            PSLanguage.INSTANCE,
-            """
-                module $newElementName where
-            """.trimIndent()
-        ) as PSFile
-        val newProperName = file.module?.nameIdentifier
+    override fun handleElementRename(name: String): PsiElement? {
+        val oldProperName = element.importName
             ?: return null
-        element.importName?.replace(newProperName)
+        val newProperName = PSPsiFactory(element.project).createQualifiedProperName(name)
+            ?: return null
+        oldProperName.replace(newProperName)
         return element
     }
 }

--- a/src/main/java/org/purescript/psi/ModuleReference.kt
+++ b/src/main/java/org/purescript/psi/ModuleReference.kt
@@ -1,9 +1,13 @@
 package org.purescript.psi
 
 import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.PsiReferenceBase
+import org.purescript.PSLanguage
 import org.purescript.file.ModuleNameIndex.Companion.fileContainingModule
 import org.purescript.file.ModuleNameIndex.Companion.getAllModuleNames
+import org.purescript.file.PSFile
 import org.purescript.psi.imports.PSImportDeclarationImpl
 
 class ModuleReference(element: PSImportDeclarationImpl) : PsiReferenceBase<PSImportDeclarationImpl>(
@@ -18,5 +22,19 @@ class ModuleReference(element: PSImportDeclarationImpl) : PsiReferenceBase<PSImp
     override fun resolve(): PSModule? {
         val moduleName = element.importName?.name ?: return null
         return fileContainingModule(element.project, moduleName)?.module
+    }
+
+    override fun handleElementRename(newElementName: String): PsiElement? {
+        val psiFileFactory = PsiFileFactory.getInstance(element.project)
+        val file = psiFileFactory.createFileFromText(
+            PSLanguage.INSTANCE,
+            """
+                module $newElementName where
+            """.trimIndent()
+        ) as PSFile
+        val newProperName = file.module?.nameIdentifier
+            ?: return null
+        element.importName?.replace(newProperName)
+        return element
     }
 }

--- a/src/main/java/org/purescript/psi/PSModule.kt
+++ b/src/main/java/org/purescript/psi/PSModule.kt
@@ -1,11 +1,10 @@
 package org.purescript.psi
 
 import com.intellij.lang.ASTNode
-import com.intellij.psi.PsiComment
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiNameIdentifierOwner
-import com.intellij.psi.PsiNamedElement
+import com.intellij.psi.*
+import org.purescript.PSLanguage
 import org.purescript.features.DocCommentOwner
+import org.purescript.file.PSFile
 import org.purescript.psi.classes.PSClassDeclaration
 import org.purescript.psi.data.PSDataDeclaration
 import org.purescript.psi.exports.*
@@ -24,7 +23,17 @@ class PSModule(node: ASTNode) :
     }
 
     override fun setName(name: String): PsiElement? {
-        return null
+        val psiFileFactory = PsiFileFactory.getInstance(project)
+        val file = psiFileFactory.createFileFromText(
+            PSLanguage.INSTANCE,
+            """
+                module $name where
+            """.trimIndent()
+        ) as PSFile
+        val newProperName = file.module?.nameIdentifier
+            ?: return null
+        nameIdentifier.replace(newProperName)
+        return this
     }
 
     override fun getNameIdentifier(): PSProperName {

--- a/src/main/java/org/purescript/psi/PSModule.kt
+++ b/src/main/java/org/purescript/psi/PSModule.kt
@@ -23,16 +23,9 @@ class PSModule(node: ASTNode) :
     }
 
     override fun setName(name: String): PsiElement? {
-        val psiFileFactory = PsiFileFactory.getInstance(project)
-        val file = psiFileFactory.createFileFromText(
-            PSLanguage.INSTANCE,
-            """
-                module $name where
-            """.trimIndent()
-        ) as PSFile
-        val newProperName = file.module?.nameIdentifier
+        val properName = PSPsiFactory(project).createQualifiedProperName(name)
             ?: return null
-        nameIdentifier.replace(newProperName)
+        nameIdentifier.replace(properName)
         return this
     }
 

--- a/src/main/java/org/purescript/psi/PSPsiFactory.kt
+++ b/src/main/java/org/purescript/psi/PSPsiFactory.kt
@@ -1,0 +1,18 @@
+package org.purescript.psi
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFileFactory
+import com.intellij.psi.util.findDescendantOfType
+import org.purescript.PSLanguage
+
+class PSPsiFactory(private val project: Project) {
+
+    fun createQualifiedProperName(name: String): PSProperName? =
+        createFromText("module $name where")
+
+    private inline fun <reified T : PsiElement> createFromText(code: String): T? =
+        PsiFileFactory.getInstance(project)
+            .createFileFromText(PSLanguage.INSTANCE, code)
+            .findDescendantOfType()
+}

--- a/src/main/java/org/purescript/psi/exports/ExportedModuleReference.kt
+++ b/src/main/java/org/purescript/psi/exports/ExportedModuleReference.kt
@@ -1,7 +1,10 @@
 package org.purescript.psi.exports
 
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.PsiReferenceBase
+import org.purescript.PSLanguage
+import org.purescript.file.PSFile
 import org.purescript.psi.imports.PSImportDeclarationImpl
 
 class ExportedModuleReference(exportedModule: PSExportedModule) : PsiReferenceBase<PSExportedModule>(
@@ -17,6 +20,20 @@ class ExportedModuleReference(exportedModule: PSExportedModule) : PsiReferenceBa
     override fun resolve(): PsiElement? =
         candidates.firstOrNull { it.name == myElement.name }
             ?.run { importAlias ?: importedModule }
+
+    override fun handleElementRename(newElementName: String): PsiElement? {
+        val psiFileFactory = PsiFileFactory.getInstance(element.project)
+        val file = psiFileFactory.createFileFromText(
+            PSLanguage.INSTANCE,
+            """
+                module $newElementName where
+            """.trimIndent()
+        ) as PSFile
+        val newProperName = file.module?.nameIdentifier
+            ?: return null
+        element.properName.replace(newProperName)
+        return element
+    }
 
     private val candidates: Array<PSImportDeclarationImpl>
         get() =

--- a/src/main/java/org/purescript/psi/exports/ExportedModuleReference.kt
+++ b/src/main/java/org/purescript/psi/exports/ExportedModuleReference.kt
@@ -1,10 +1,8 @@
 package org.purescript.psi.exports
 
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.PsiReferenceBase
-import org.purescript.PSLanguage
-import org.purescript.file.PSFile
+import org.purescript.psi.PSPsiFactory
 import org.purescript.psi.imports.PSImportDeclarationImpl
 
 class ExportedModuleReference(exportedModule: PSExportedModule) : PsiReferenceBase<PSExportedModule>(
@@ -21,15 +19,8 @@ class ExportedModuleReference(exportedModule: PSExportedModule) : PsiReferenceBa
         candidates.firstOrNull { it.name == myElement.name }
             ?.run { importAlias ?: importedModule }
 
-    override fun handleElementRename(newElementName: String): PsiElement? {
-        val psiFileFactory = PsiFileFactory.getInstance(element.project)
-        val file = psiFileFactory.createFileFromText(
-            PSLanguage.INSTANCE,
-            """
-                module $newElementName where
-            """.trimIndent()
-        ) as PSFile
-        val newProperName = file.module?.nameIdentifier
+    override fun handleElementRename(name: String): PsiElement? {
+        val newProperName = PSPsiFactory(element.project).createQualifiedProperName(name)
             ?: return null
         element.properName.replace(newProperName)
         return element

--- a/src/main/java/org/purescript/psi/exports/PSExportedItem.kt
+++ b/src/main/java/org/purescript/psi/exports/PSExportedItem.kt
@@ -25,44 +25,40 @@ class PSExportedData(node: ASTNode) : PSExportedItem(node) {
 
 class PSExportedClass(node: ASTNode) : PSExportedItem(node) {
     private val properName: PSProperName
-        get() =
-            findNotNullChildByClass(PSProperName::class.java)
+        get() = findNotNullChildByClass(PSProperName::class.java)
 
     override fun getName(): String = properName.name
 }
 
 class PSExportedKind(node: ASTNode) : PSExportedItem(node) {
     private val properName: PSProperName
-        get() =
-            findNotNullChildByClass(PSProperName::class.java)
+        get() = findNotNullChildByClass(PSProperName::class.java)
 
     override fun getName(): String = properName.name
 }
 
 class PSExportedOperator(node: ASTNode) : PSExportedItem(node) {
     private val identifier: PSIdentifier
-        get() =
-            findNotNullChildByClass(PSIdentifier::class.java)
+        get() = findNotNullChildByClass(PSIdentifier::class.java)
 
     override fun getName(): String = identifier.name
 }
 
 class PSExportedType(node: ASTNode) : PSExportedItem(node) {
     private val identifier: PSIdentifier
-        get() =
-            findNotNullChildByClass(PSIdentifier::class.java)
+        get() = findNotNullChildByClass(PSIdentifier::class.java)
 
     override fun getName(): String = identifier.name
 }
 
 class PSExportedModule(node: ASTNode) : PSExportedItem(node) {
-    val properName = findNotNullChildByClass(PSProperName::class.java)
+    val properName: PSProperName
+        get() = findNotNullChildByClass(PSProperName::class.java)
 
     val importDeclaration: PSImportDeclarationImpl?
-        get() =
-            module?.importDeclarations?.singleOrNull {
-                it.name == properName.name
-            }
+        get() = module?.importDeclarations?.singleOrNull {
+            it.name == properName.name
+        }
 
     override fun getName(): String = properName.name
 
@@ -73,7 +69,8 @@ class PSExportedModule(node: ASTNode) : PSExportedItem(node) {
 
 class PSExportedValue(node: ASTNode) : PSExportedItem(node) {
 
-    val identifier = findNotNullChildByClass(PSIdentifier::class.java)
+    val identifier: PSIdentifier
+        get() = findNotNullChildByClass(PSIdentifier::class.java)
 
     override fun getName() = identifier.name
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -51,6 +51,7 @@
     <internalFileTemplate name="Purescript Module"/>
     <lang.documentationProvider language="Purescript" implementationClass="org.purescript.features.PSDocumentationProvider"/>
     <lang.foldingBuilder language="Purescript" implementationClass="org.purescript.ide.folding.PurescriptFoldingBuilder"/>
+    <lang.refactoringSupport language="Purescript" implementationClass="org.purescript.ide.refactoring.PSRefactoringSupportProvider"/>
 
     <!-- LSP server support START-->
     <postStartupActivity

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -52,6 +52,7 @@
     <lang.documentationProvider language="Purescript" implementationClass="org.purescript.features.PSDocumentationProvider"/>
     <lang.foldingBuilder language="Purescript" implementationClass="org.purescript.ide.folding.PurescriptFoldingBuilder"/>
     <lang.refactoringSupport language="Purescript" implementationClass="org.purescript.ide.refactoring.PSRefactoringSupportProvider"/>
+    <lang.namesValidator language="Purescript" implementationClass="org.purescript.ide.refactoring.PSNamesValidator" />
 
     <!-- LSP server support START-->
     <postStartupActivity

--- a/src/test/java/org/purescript/psi/ModuleReferenceTest.kt
+++ b/src/test/java/org/purescript/psi/ModuleReferenceTest.kt
@@ -97,4 +97,19 @@ class ModuleReferenceTest : BasePlatformTestCase() {
         )
         myFixture.testCompletionVariants("Foo.purs", "Bar", "Foo")
     }
+
+    fun `test renames module`() {
+        val module = myFixture.configureByText("Foo.purs", "module Foo where").getModule()
+        val importDeclaration = myFixture.configureByText(
+            "Bar.purs",
+            """
+                module Bar where
+                import <caret>Foo
+            """.trimIndent()
+        ).getImportDeclaration()
+        myFixture.renameElementAtCaret("Qux")
+
+        assertEquals("Qux", importDeclaration.name)
+        assertEquals("Qux", module.name)
+    }
 }

--- a/src/test/java/org/purescript/psi/PSModuleTest.kt
+++ b/src/test/java/org/purescript/psi/PSModuleTest.kt
@@ -4,7 +4,6 @@ import com.intellij.psi.PsiFile
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import junit.framework.TestCase
 import org.purescript.*
-import org.purescript.file.PSFile
 
 class PSModuleTest : BasePlatformTestCase() {
 
@@ -417,6 +416,30 @@ class PSModuleTest : BasePlatformTestCase() {
         ).getModule().exportedTypeSynonymDeclarations
 
         assertSize(2, exportedTypeSynonymDeclarations)
+    }
+
+    fun `test rename simple`() {
+        val module = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module <caret>Foo where
+            """.trimIndent()
+        ).getModule()
+        myFixture.renameElementAtCaret("Bar")
+
+        assertEquals("Bar", module.name)
+    }
+
+    fun `test rename qualified`() {
+        val module = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module <caret>Foo where
+            """.trimIndent()
+        ).getModule()
+        myFixture.renameElementAtCaret("Foo.Bar")
+
+        assertEquals("Foo.Bar", module.name)
     }
 }
 

--- a/src/test/java/org/purescript/psi/PSPsiFactoryTest.kt
+++ b/src/test/java/org/purescript/psi/PSPsiFactoryTest.kt
@@ -1,0 +1,14 @@
+package org.purescript.psi
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+class PSPsiFactoryTest : BasePlatformTestCase() {
+
+    fun `test create qualified proper name`() {
+        with(PSPsiFactory(project)) {
+            assertEquals("Foo", createQualifiedProperName("Foo")!!.name)
+            assertEquals("Foo.Bar", createQualifiedProperName("Foo.Bar")!!.name)
+            assertNull(createQualifiedProperName("foo"))
+        }
+    }
+}

--- a/src/test/java/org/purescript/psi/exports/ExportedModuleReferenceTest.kt
+++ b/src/test/java/org/purescript/psi/exports/ExportedModuleReferenceTest.kt
@@ -123,4 +123,19 @@ class ExportedModuleReferenceTest : BasePlatformTestCase() {
 
         assertEquals(exportedModule, usageInfo.element)
     }
+
+    fun `test renames module`() {
+        val module = myFixture.configureByText("Foo.purs", "module Foo where").getModule()
+        val exportedModule = myFixture.configureByText(
+            "Bar.purs",
+            """
+                module Bar (module <caret>Foo) where
+                import Foo
+            """.trimIndent()
+        ).getExportedModule()
+        myFixture.renameElementAtCaret("Qux")
+
+        assertEquals("Qux", exportedModule.name)
+        assertEquals("Qux", module.name)
+    }
 }


### PR DESCRIPTION

https://user-images.githubusercontent.com/5345337/113281806-57512080-92e6-11eb-933a-09a81e8bf589.mov

There are more improvements that can be done:
- Prompt the user if the file should be renamed
- Check that it's a valid module name
- Check for conflicts with other modules

I'm choosing to make a PR here, otherwise it's going to be too big.