### PR TITLE
Improve handling of partially imported data and newtype declarations

### DIFF
--- a/src/main/java/org/purescript/psi/exports/ExportedDataMemberReference.kt
+++ b/src/main/java/org/purescript/psi/exports/ExportedDataMemberReference.kt
@@ -4,6 +4,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNamedElement
 import com.intellij.psi.PsiReferenceBase
 import org.purescript.psi.data.PSDataDeclaration
+import org.purescript.psi.newtype.PSNewTypeDeclarationImpl
 
 class ExportedDataMemberReference(exportedDataMember: PSExportedDataMember) : PsiReferenceBase<PSExportedDataMember>(
     exportedDataMember,
@@ -20,7 +21,7 @@ class ExportedDataMemberReference(exportedDataMember: PSExportedDataMember) : Ps
     private val candidates: Array<out PsiNamedElement>
         get() = when (val declaration = myElement.exportedData?.reference?.resolve()) {
             is PSDataDeclaration -> declaration.dataConstructorList?.dataConstructors ?: emptyArray()
+            is PSNewTypeDeclarationImpl -> arrayOf(declaration.newTypeConstructor)
             else -> emptyArray()
         }
-
 }

--- a/src/main/java/org/purescript/psi/exports/PSExportedItem.kt
+++ b/src/main/java/org/purescript/psi/exports/PSExportedItem.kt
@@ -2,10 +2,12 @@ package org.purescript.psi.exports
 
 import com.intellij.lang.ASTNode
 import org.purescript.psi.PSPsiElement
+import org.purescript.psi.data.PSDataDeclaration
 import org.purescript.psi.imports.PSImportDeclarationImpl
 import org.purescript.psi.name.PSIdentifier
 import org.purescript.psi.name.PSModuleName
 import org.purescript.psi.name.PSProperName
+import org.purescript.psi.newtype.PSNewTypeDeclarationImpl
 
 sealed class PSExportedItem(node: ASTNode) : PSPsiElement(node) {
     abstract override fun getName(): String
@@ -17,6 +19,18 @@ class PSExportedData(node: ASTNode) : PSExportedItem(node) {
 
     val dataMemberList: PSExportedDataMemberList?
         get() = findChildByClass(PSExportedDataMemberList::class.java)
+
+    val exportsAll: Boolean
+        get() = dataMemberList?.doubleDot != null
+
+    val dataMembers: Array<PSExportedDataMember>
+        get() = dataMemberList?.dataMembers ?: emptyArray()
+
+    val newTypeDeclaration: PSNewTypeDeclarationImpl?
+        get() = reference.resolve() as? PSNewTypeDeclarationImpl
+
+    val dataDeclaration: PSDataDeclaration?
+        get() = reference.resolve() as? PSDataDeclaration
 
     override fun getName(): String = properName.name
 

--- a/src/main/java/org/purescript/psi/expression/ExpressionConstructorReference.kt
+++ b/src/main/java/org/purescript/psi/expression/ExpressionConstructorReference.kt
@@ -24,18 +24,11 @@ class ExpressionConstructorReference(expressionConstructor: PSExpressionConstruc
         get() {
             val module = element.module ?: return emptySequence()
             return sequence {
-                for (newTypeDeclaration in module.newTypeDeclarations) {
-                    yield(newTypeDeclaration.newTypeConstructor)
-                }
-                for (dataDeclaration in module.dataDeclarations) {
-                    yieldAll(dataDeclaration.dataConstructors.iterator())
-                }
-                yieldAll(module.importDeclarations.flatMap { it.importedNewTypeConstructors })
-                for (importDeclaration in module.importDeclarations) {
-                    for (importedDataDeclaration in importDeclaration.importedDataDeclarations) {
-                        yieldAll(importedDataDeclaration.dataConstructors.iterator())
-                    }
-                }
+                yieldAll(module.newTypeConstructors)
+                yieldAll(module.dataConstructors)
+                val importDeclarations = module.importDeclarations
+                yieldAll(importDeclarations.flatMap { it.importedNewTypeConstructors })
+                yieldAll(importDeclarations.flatMap { it.importedDataConstructors })
             }
         }
 

--- a/src/main/java/org/purescript/psi/expression/ExpressionConstructorReference.kt
+++ b/src/main/java/org/purescript/psi/expression/ExpressionConstructorReference.kt
@@ -30,10 +30,8 @@ class ExpressionConstructorReference(expressionConstructor: PSExpressionConstruc
                 for (dataDeclaration in module.dataDeclarations) {
                     yieldAll(dataDeclaration.dataConstructors.iterator())
                 }
+                yieldAll(module.importDeclarations.flatMap { it.importedNewTypeConstructors })
                 for (importDeclaration in module.importDeclarations) {
-                    for (importedNewTypeDeclaration in importDeclaration.importedNewTypeDeclarations) {
-                        yield(importedNewTypeDeclaration.newTypeConstructor)
-                    }
                     for (importedDataDeclaration in importDeclaration.importedDataDeclarations) {
                         yieldAll(importedDataDeclaration.dataConstructors.iterator())
                     }

--- a/src/main/java/org/purescript/psi/expression/PSExpressionConstructor.kt
+++ b/src/main/java/org/purescript/psi/expression/PSExpressionConstructor.kt
@@ -18,7 +18,7 @@ import org.purescript.psi.name.PSQualifiedProperName
 class PSExpressionConstructor(node: ASTNode) : PSPsiElement(node) {
 
     /**
-     * @return the [PSQualifiedProperName] identifying this consgtructor
+     * @return the [PSQualifiedProperName] identifying this constructor
      */
     internal val qualifiedProperName: PSQualifiedProperName
         get() = findNotNullChildByClass(PSQualifiedProperName::class.java)

--- a/src/main/java/org/purescript/psi/imports/PSImportDeclarationImpl.kt
+++ b/src/main/java/org/purescript/psi/imports/PSImportDeclarationImpl.kt
@@ -225,7 +225,7 @@ class PSImportDeclarationImpl(node: ASTNode) : PSPsiElement(node) {
                     if (importedData.importsAll) {
                         importedDataConstructors.addAll(dataConstructors)
                     } else {
-                        val importedDataConstructorNames = importedData.importedDataMembers.map { name }
+                        val importedDataConstructorNames = importedData.importedDataMembers.map { it.name }
                         dataConstructors.filterTo(importedDataConstructors) { it.name in importedDataConstructorNames }
                     }
                 }

--- a/src/main/java/org/purescript/psi/imports/PSImportedDataMember.kt
+++ b/src/main/java/org/purescript/psi/imports/PSImportedDataMember.kt
@@ -2,5 +2,11 @@ package org.purescript.psi.imports
 
 import com.intellij.lang.ASTNode
 import org.purescript.psi.PSPsiElement
+import org.purescript.psi.name.PSProperName
 
-class PSImportedDataMember(node: ASTNode) : PSPsiElement(node)
+class PSImportedDataMember(node: ASTNode) : PSPsiElement(node) {
+    val properName: PSProperName
+        get() = findNotNullChildByClass(PSProperName::class.java)
+
+    override fun getName(): String = properName.name
+}

--- a/src/main/java/org/purescript/psi/imports/PSImportedItem.kt
+++ b/src/main/java/org/purescript/psi/imports/PSImportedItem.kt
@@ -51,22 +51,44 @@ class PSImportedClass(node: ASTNode) : PSImportedItem(node) {
  * ```
  */
 class PSImportedData(node: ASTNode) : PSImportedItem(node) {
+    /**
+     * @return the [PSProperName] identifying this element
+     */
     internal val properName: PSProperName
-        get() =
-            findNotNullChildByClass(PSProperName::class.java)
+        get() = findNotNullChildByClass(PSProperName::class.java)
 
+    /**
+     * @return the [PSImportedDataMemberList] containing the imported members,
+     * if present
+     */
     internal val importedDataMemberList: PSImportedDataMemberList?
         get() = findChildByClass(PSImportedDataMemberList::class.java)
 
+    /**
+     * @return true if this element implicitly imports all members using
+     * the (..) syntax, otherwise false
+     */
     val importsAll: Boolean
         get() = importedDataMemberList?.doubleDot != null
 
+    /**
+     * @return the data members imported explicitly using the
+     * Type(A, B, C) syntax
+     */
     val importedDataMembers: Array<PSImportedDataMember>
         get() = importedDataMemberList?.dataMembers ?: emptyArray()
 
+    /**
+     * @return the [PSNewTypeDeclarationImpl] that this element references to,
+     * if it exists
+     */
     val newTypeDeclaration: PSNewTypeDeclarationImpl?
         get() = reference.resolve() as? PSNewTypeDeclarationImpl
 
+    /**
+     * @return the [PSDataDeclaration] that this element references to,
+     * if it exists
+     */
     val dataDeclaration: PSDataDeclaration?
         get() = reference.resolve() as? PSDataDeclaration
 

--- a/src/main/java/org/purescript/psi/imports/PSImportedItem.kt
+++ b/src/main/java/org/purescript/psi/imports/PSImportedItem.kt
@@ -2,9 +2,11 @@ package org.purescript.psi.imports
 
 import com.intellij.lang.ASTNode
 import com.intellij.psi.util.PsiTreeUtil
+import org.purescript.psi.PSPsiElement
+import org.purescript.psi.data.PSDataDeclaration
 import org.purescript.psi.name.PSIdentifier
 import org.purescript.psi.name.PSProperName
-import org.purescript.psi.PSPsiElement
+import org.purescript.psi.newtype.PSNewTypeDeclarationImpl
 
 /**
  * Any element that can occur in a [PSImportList]
@@ -53,9 +55,25 @@ class PSImportedData(node: ASTNode) : PSImportedItem(node) {
         get() =
             findNotNullChildByClass(PSProperName::class.java)
 
+    internal val importedDataMemberList: PSImportedDataMemberList?
+        get() = findChildByClass(PSImportedDataMemberList::class.java)
+
+    val importsAll: Boolean
+        get() = importedDataMemberList?.doubleDot != null
+
+    val importedDataMembers: Array<PSImportedDataMember>
+        get() = importedDataMemberList?.dataMembers ?: emptyArray()
+
+    val newTypeDeclaration: PSNewTypeDeclarationImpl?
+        get() = reference.resolve() as? PSNewTypeDeclarationImpl
+
+    val dataDeclaration: PSDataDeclaration?
+        get() = reference.resolve() as? PSDataDeclaration
+
     override fun getName(): String = properName.name
 
-    override fun getReference(): ImportedDataReference = ImportedDataReference(this)
+    override fun getReference(): ImportedDataReference =
+        ImportedDataReference(this)
 }
 
 /**

--- a/src/main/java/org/purescript/psi/name/PSProperName.kt
+++ b/src/main/java/org/purescript/psi/name/PSProperName.kt
@@ -3,8 +3,13 @@ package org.purescript.psi.name
 import com.intellij.lang.ASTNode
 import org.purescript.psi.PSPsiElement
 
+/**
+ * A proper name is any identifier that starts in a capital letter, like
+ * - Maybe
+ * - Nothing
+ * - Just
+ * - Eq
+ */
 class PSProperName(node: ASTNode) : PSPsiElement(node) {
-    override fun getName(): String {
-        return text.trim()
-    }
+    override fun getName(): String = text.trim()
 }

--- a/src/main/java/org/purescript/psi/name/PSQualifiedProperName.kt
+++ b/src/main/java/org/purescript/psi/name/PSQualifiedProperName.kt
@@ -3,13 +3,47 @@ package org.purescript.psi.name
 import com.intellij.lang.ASTNode
 import org.purescript.psi.PSPsiElement
 
+/**
+ * A qualified proper name, e.g.
+ * ```
+ * Data.Maybe.Nothing
+ * ```
+ * in
+ * ```
+ * import Data.Maybe as Data.Maybe
+ * f = Data.Maybe.Nothing
+ */
 class PSQualifiedProperName(node: ASTNode) : PSPsiElement(node) {
 
+    /**
+     * @return the module prefix of this element, including the dot, e.g.
+     * ```
+     * Data.Maybe.
+     * ```
+     * in
+     * ```
+     * Data.Maybe.Nothing
+     * ```
+     */
     val moduleName: PSModuleName?
         get() = findChildByClass(PSModuleName::class.java)
 
+
+    /**
+     * @return the proper name part of this element, e.g.
+     * ```
+     * Nothing
+     * ```
+     * in
+     * ```
+     * Data.Maybe.Nothing
+     * ```
+     */
     val properName: PSProperName
         get() = findNotNullChildByClass(PSProperName::class.java)
 
+    /**
+     * @return the name of the [PSProperName] that this element contains
+     */
     override fun getName(): String = properName.name
 }

--- a/src/test/java/org/purescript/psi/PSModuleTest.kt
+++ b/src/test/java/org/purescript/psi/PSModuleTest.kt
@@ -441,5 +441,61 @@ class PSModuleTest : BasePlatformTestCase() {
 
         assertEquals("Foo.Bar", module.name)
     }
+
+    fun `test finds newtype constructors`() {
+        val module = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo where
+                newtype A = B Int
+            """.trimIndent()
+        ).getModule()
+
+        assertSize(1, module.newTypeConstructors)
+    }
+
+    fun `test finds data constructors`() {
+        val module = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo where
+                data A
+                    = B
+                    | C
+                    | D
+            """.trimIndent()
+        ).getModule()
+
+        assertSize(3, module.dataConstructors)
+    }
+
+    fun `test finds exported newtype constructors`() {
+        val module = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo (A(A), B(..), C) where
+                newtype A = A Int
+                newtype B = B Int
+                newtype C = C Int
+            """.trimIndent()
+        ).getModule()
+
+        assertSize(2, module.exportedNewTypeConstructors)
+    }
+
+    fun `test finds exported data constructors`() {
+        val module = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo (A(B, C)) where
+                data A 
+                    = A Int
+                    | B Int
+                    | C Int
+            """.trimIndent()
+        ).getModule()
+
+        assertSize(2, module.exportedDataConstructors)
+    }
 }
 

--- a/src/test/java/org/purescript/psi/exports/ExportedDataMemberReferenceTest.kt
+++ b/src/test/java/org/purescript/psi/exports/ExportedDataMemberReferenceTest.kt
@@ -3,6 +3,7 @@ package org.purescript.psi.exports
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import org.purescript.getDataConstructor
 import org.purescript.getExportedDataMember
+import org.purescript.getNewTypeConstructor
 
 class ExportedDataMemberReferenceTest : BasePlatformTestCase() {
 
@@ -56,7 +57,7 @@ class ExportedDataMemberReferenceTest : BasePlatformTestCase() {
         myFixture.testCompletionVariants("Foo.purs", "Basket", "Bat", "Banana")
     }
 
-    fun `test finds usage of dataconstructor`() {
+    fun `test finds usage of data constructor`() {
         val exportedDataMember = myFixture.configureByText(
             "Foo.purs",
             """
@@ -65,6 +66,41 @@ class ExportedDataMemberReferenceTest : BasePlatformTestCase() {
                     = Basket
                     | Bat
                     | <caret>Banana
+            """.trimIndent()
+        ).getExportedDataMember()
+        val usageInfo = myFixture.testFindUsages("Foo.purs").single()
+        assertEquals(exportedDataMember, usageInfo.element)
+    }
+
+    fun `test resolves to newtype constructor`() {
+        val file = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo (Bar(Qux)) where
+                newtype Bar = Qux Int
+            """.trimIndent()
+        )
+
+        assertEquals(file.getNewTypeConstructor(), file.getExportedDataMember().reference.resolve())
+    }
+
+    fun `test completes newtype constructor`() {
+        myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo (Bar(<caret>)) where
+                newtype Bar = Banana Int
+            """.trimIndent()
+        )
+        myFixture.testCompletionVariants("Foo.purs", "Banana")
+    }
+
+    fun `test finds usage of newtype constructor`() {
+        val exportedDataMember = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo (Bar(Banana)) where
+                newtype Bar = <caret>Banana Int
             """.trimIndent()
         ).getExportedDataMember()
         val usageInfo = myFixture.testFindUsages("Foo.purs").single()

--- a/src/test/java/org/purescript/psi/expression/ExpressionConstructorReferenceTest.kt
+++ b/src/test/java/org/purescript/psi/expression/ExpressionConstructorReferenceTest.kt
@@ -1,7 +1,10 @@
 package org.purescript.psi.expression
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import org.purescript.*
+import org.purescript.getDataConstructor
+import org.purescript.getDataDeclaration
+import org.purescript.getExpressionConstructor
+import org.purescript.getNewTypeConstructor
 
 class ExpressionConstructorReferenceTest : BasePlatformTestCase() {
     fun `test resolves local data declaration constructors`() {
@@ -179,5 +182,45 @@ class ExpressionConstructorReferenceTest : BasePlatformTestCase() {
         val usageInfo = myFixture.findUsages(newTypeConstructor).single()
 
         assertEquals(expressionConstructor, usageInfo.element)
+    }
+
+    fun `test does not resolve imported expression constructor when constructor not exported`() {
+        myFixture.configureByText(
+            "Hup.purs",
+            """
+                module Hup (Bar) where
+                newtype Bar = Qux String
+            """.trimIndent()
+        )
+        val expressionConstructor = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo where
+                import Hup
+                f = Qux ""
+            """.trimIndent()
+        ).getExpressionConstructor()
+
+        assertNull(expressionConstructor.reference.resolve())
+    }
+
+    fun `test does not resolve imported expression constructor when constructor not imported`() {
+        myFixture.configureByText(
+            "Hup.purs",
+            """
+                module Hup where
+                newtype Bar = Qux String
+            """.trimIndent()
+        )
+        val expressionConstructor = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo where
+                import Hup (Bar)
+                f = Qux ""
+            """.trimIndent()
+        ).getExpressionConstructor()
+
+        assertNull(expressionConstructor.reference.resolve())
     }
 }

--- a/src/test/java/org/purescript/psi/expression/ExpressionConstructorReferenceTest.kt
+++ b/src/test/java/org/purescript/psi/expression/ExpressionConstructorReferenceTest.kt
@@ -283,4 +283,24 @@ class ExpressionConstructorReferenceTest : BasePlatformTestCase() {
 
         assertNull(expressionConstructor.reference.resolve())
     }
+
+    fun `test resolves imported data constructor with explicitly imported constructor`() {
+        val dataConstructor = myFixture.configureByText(
+            "Maybe.purs",
+            """
+                module Data.Maybe where
+                data Maybe a = Just a
+            """.trimIndent()
+        ).getDataConstructor()
+        val expressionConstructor = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo where
+                import Data.Maybe (Maybe(Just))
+                f = Just 3
+            """.trimIndent()
+        ).getExpressionConstructor()
+
+        assertEquals(dataConstructor, expressionConstructor.reference.resolve())
+    }
 }

--- a/src/test/java/org/purescript/psi/expression/ExpressionConstructorReferenceTest.kt
+++ b/src/test/java/org/purescript/psi/expression/ExpressionConstructorReferenceTest.kt
@@ -184,7 +184,7 @@ class ExpressionConstructorReferenceTest : BasePlatformTestCase() {
         assertEquals(expressionConstructor, usageInfo.element)
     }
 
-    fun `test does not resolve imported expression constructor when constructor not exported`() {
+    fun `test does not resolve imported newtype constructor when constructor not exported`() {
         myFixture.configureByText(
             "Hup.purs",
             """
@@ -204,7 +204,7 @@ class ExpressionConstructorReferenceTest : BasePlatformTestCase() {
         assertNull(expressionConstructor.reference.resolve())
     }
 
-    fun `test does not resolve imported expression constructor when constructor not imported`() {
+    fun `test does not resolve imported newtype constructor when constructor not imported`() {
         myFixture.configureByText(
             "Hup.purs",
             """
@@ -217,6 +217,66 @@ class ExpressionConstructorReferenceTest : BasePlatformTestCase() {
             """
                 module Foo where
                 import Hup (Bar)
+                f = Qux ""
+            """.trimIndent()
+        ).getExpressionConstructor()
+
+        assertNull(expressionConstructor.reference.resolve())
+    }
+
+    fun `test does not resolve imported data constructor when constructor not exported`() {
+        myFixture.configureByText(
+            "Hup.purs",
+            """
+                module Hup (Bar(Baz)) where
+                data Bar = Qux String | Baz
+            """.trimIndent()
+        )
+        val expressionConstructor = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo where
+                import Hup
+                f = Qux ""
+            """.trimIndent()
+        ).getExpressionConstructor()
+
+        assertNull(expressionConstructor.reference.resolve())
+    }
+
+    fun `test does not resolve imported data constructor when constructor not imported`() {
+        myFixture.configureByText(
+            "Hup.purs",
+            """
+                module Hup where
+                data Bar = Qux String | Baz
+            """.trimIndent()
+        )
+        val expressionConstructor = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo where
+                import Hup (Baz)
+                f = Qux ""
+            """.trimIndent()
+        ).getExpressionConstructor()
+
+        assertNull(expressionConstructor.reference.resolve())
+    }
+
+    fun `test does not resolve imported data constructor when constructor is hidden`() {
+        myFixture.configureByText(
+            "Hup.purs",
+            """
+                module Hup where
+                data Bar = Qux String | Baz
+            """.trimIndent()
+        )
+        val expressionConstructor = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo where
+                import Hup hiding (Bar(..))
                 f = Qux ""
             """.trimIndent()
         ).getExpressionConstructor()

--- a/src/test/java/org/purescript/psi/expression/PSExpressionConstructorTest.kt
+++ b/src/test/java/org/purescript/psi/expression/PSExpressionConstructorTest.kt
@@ -15,4 +15,16 @@ class PSExpressionConstructorTest : BasePlatformTestCase() {
 
         assertEquals("Bar", expressionConstructor.name)
     }
+
+    fun `test gets qualified name`() {
+        val expressionConstructor = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo where
+                val = Qux.Bar
+            """.trimIndent()
+        ).getExpressionConstructor()
+
+        assertEquals("Bar", expressionConstructor.name)
+    }
 }

--- a/src/test/java/org/purescript/psi/imports/PSImportedDataTest.kt
+++ b/src/test/java/org/purescript/psi/imports/PSImportedDataTest.kt
@@ -1,8 +1,9 @@
 package org.purescript.psi.imports
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.purescript.getDataDeclaration
 import org.purescript.getImportedData
-
+import org.purescript.getNewTypeDeclaration
 
 class PSImportedDataTest : BasePlatformTestCase() {
 
@@ -14,6 +15,103 @@ class PSImportedDataTest : BasePlatformTestCase() {
                 import Bar (Qux)
             """.trimIndent()
         ).getImportedData()
+
         assertEquals("Qux", importedData.name)
+    }
+
+    fun `test parses non-existing data member list`() {
+        val importedData = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo where
+                import Bar (Qux)
+            """.trimIndent()
+        ).getImportedData()
+
+        assertNull(importedData.importedDataMemberList)
+        assertFalse(importedData.importsAll)
+        assertEmpty(importedData.importedDataMembers)
+    }
+
+    fun `test parses double dot data member list`() {
+        val importedData = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo where
+                import Bar (Qux(..))
+            """.trimIndent()
+        ).getImportedData()
+
+        assertNotNull(importedData.importedDataMemberList)
+        assertTrue(importedData.importsAll)
+        assertEmpty(importedData.importedDataMembers)
+    }
+
+    fun `test parses empty data member list`() {
+        val importedData = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo where
+                import Bar (Qux())
+            """.trimIndent()
+        ).getImportedData()
+
+        assertNotNull(importedData.importedDataMemberList)
+        assertFalse(importedData.importsAll)
+        assertEmpty(importedData.importedDataMembers)
+    }
+
+    fun `test parses regular data member list`() {
+        val importedData = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo where
+                import Bar (Qux(A, B, C))
+            """.trimIndent()
+        ).getImportedData()
+
+        assertNotNull(importedData.importedDataMemberList)
+        assertFalse(importedData.importsAll)
+        assertSize(3, importedData.importedDataMembers)
+    }
+
+    fun `test newtype declaration property`() {
+        val newTypeDeclaration = myFixture.configureByText(
+            "Bar.purs",
+            """
+                module Bar where
+                newtype Qux = A Int
+            """.trimIndent()
+        ).getNewTypeDeclaration()
+        val importedData = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo where
+                import Bar (Qux)
+            """.trimIndent()
+        ).getImportedData()
+
+        assertEquals(newTypeDeclaration, importedData.newTypeDeclaration)
+        assertNull(importedData.dataDeclaration)
+    }
+
+    fun `test data declaration property`() {
+        val dataDeclaration = myFixture.configureByText(
+            "Bar.purs",
+            """
+                module Bar where
+                data Qux = A Int
+            """.trimIndent()
+        ).getDataDeclaration()
+        val importedData = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo where
+                import Bar (Qux)
+            """.trimIndent()
+        ).getImportedData()
+
+        assertEquals(dataDeclaration, importedData.dataDeclaration)
+        assertNull(importedData.newTypeDeclaration)
     }
 }


### PR DESCRIPTION

https://user-images.githubusercontent.com/5345337/114282308-5ab17e00-9a43-11eb-8980-90adcfcec6f3.mov

This PR is a bit all over the place. There were a couple of things that I realized too late that they were missing, like support for navigation between exported members and newtype declarations. I meant to have some better support for qualified expression constructors, but that's going to have to be a different PR.