### PR TITLE
Implement inspection and quick fix for unresolved type constructors (depends on #252)

### DIFF
--- a/src/main/java/org/purescript/PSLanguage.kt
+++ b/src/main/java/org/purescript/PSLanguage.kt
@@ -7,7 +7,7 @@ class PSLanguage : Language("Purescript", "text/purescript", "text/x-purescript"
         val INSTANCE = PSLanguage()
 
         /**
-         * These modules are built in to the purescript compiler,
+         * These modules are built into the purescript compiler,
          * and have no corresponding source files.
          *
          * See [https://pursuit.purescript.org/builtins/docs/Prim] for details.
@@ -21,6 +21,20 @@ class PSLanguage : Language("Purescript", "text/purescript", "text/x-purescript"
             "Prim.RowList",
             "Prim.Symbol",
             "Prim.TypeError",
+        )
+
+        /**
+         * These types are built into the purescript compiles,
+         * and are always available.
+         *
+         * See [https://pursuit.purescript.org/builtins/docs/Prim] for details.
+         */
+        val BUILTIN_TYPES = listOf(
+            "Int",
+            "Number",
+            "String",
+            "Char",
+            "Boolean"
         )
     }
 }

--- a/src/main/java/org/purescript/PSLanguage.kt
+++ b/src/main/java/org/purescript/PSLanguage.kt
@@ -34,7 +34,9 @@ class PSLanguage : Language("Purescript", "text/purescript", "text/x-purescript"
             "Number",
             "String",
             "Char",
-            "Boolean"
+            "Boolean",
+            "Array",
+            "Type", // TODO Type is really a kind, not a type
         )
     }
 }

--- a/src/main/java/org/purescript/PSLanguage.kt
+++ b/src/main/java/org/purescript/PSLanguage.kt
@@ -12,7 +12,7 @@ class PSLanguage : Language("Purescript", "text/purescript", "text/x-purescript"
          *
          * See [https://pursuit.purescript.org/builtins/docs/Prim] for details.
          */
-        val BUILTIN_MODULES = listOf(
+        val BUILTIN_MODULES = setOf(
             "Prim",
             "Prim.Boolean",
             "Prim.Coerce",
@@ -29,7 +29,7 @@ class PSLanguage : Language("Purescript", "text/purescript", "text/x-purescript"
          *
          * See [https://pursuit.purescript.org/builtins/docs/Prim] for details.
          */
-        val BUILTIN_TYPES = listOf(
+        val BUILTIN_TYPES = setOf(
             "Int",
             "Number",
             "String",

--- a/src/main/java/org/purescript/PSLanguage.kt
+++ b/src/main/java/org/purescript/PSLanguage.kt
@@ -37,6 +37,7 @@ class PSLanguage : Language("Purescript", "text/purescript", "text/x-purescript"
             "Boolean",
             "Array",
             "Type", // TODO Type is really a kind, not a type
+            "Row", // TODO Row is really a kind, not a type
         )
     }
 }

--- a/src/main/java/org/purescript/features/PSFindUsageProvider.kt
+++ b/src/main/java/org/purescript/features/PSFindUsageProvider.kt
@@ -34,6 +34,7 @@ import org.purescript.parser.PSTokens.Companion.STRING
 import org.purescript.parser.PSTokens.Companion.STRING_ERROR
 import org.purescript.parser.PSTokens.Companion.STRING_ESCAPED
 import org.purescript.parser.PSTokens.Companion.STRING_GAP
+import org.purescript.psi.PSForeignDataDeclaration
 import org.purescript.psi.PSForeignValueDeclaration
 import org.purescript.psi.PSModule
 import org.purescript.psi.PSVarBinderImpl
@@ -63,6 +64,7 @@ class PSFindUsageProvider : FindUsagesProvider {
             || psiElement is PSTypeSynonymDeclaration
             || psiElement is PSClassMember
             || psiElement is PSFixityDeclaration
+            || psiElement is PSForeignDataDeclaration
 
     override fun getWordsScanner(): WordsScanner {
         val psWordScanner = DefaultWordsScanner(
@@ -115,6 +117,7 @@ class PSFindUsageProvider : FindUsagesProvider {
             is PSDataConstructor -> "data constructor"
             is PSClassDeclaration -> "class"
             is PSForeignValueDeclaration -> "foreign value"
+            is PSForeignDataDeclaration -> "foreign data"
             is PSTypeSynonymDeclaration -> "type synonym"
             is PSClassMember -> "class member"
             is PSFixityDeclaration -> "operator"

--- a/src/main/java/org/purescript/file/ExportedTypesIndex.kt
+++ b/src/main/java/org/purescript/file/ExportedTypesIndex.kt
@@ -1,0 +1,68 @@
+package org.purescript.file
+
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.util.indexing.*
+import com.intellij.util.io.EnumeratorStringDescriptor
+import org.purescript.psi.PSForeignDataDeclaration
+import org.purescript.psi.data.PSDataDeclaration
+import org.purescript.psi.newtype.PSNewTypeDeclarationImpl
+import org.purescript.psi.typesynonym.PSTypeSynonymDeclaration
+
+/**
+ * An index on what type declarations every module exports.
+ * The index contains the following declarations:
+ *  - [PSTypeSynonymDeclaration]
+ *  - [PSDataDeclaration]
+ *  - [PSNewTypeDeclarationImpl]
+ *  - [PSForeignDataDeclaration]
+ */
+class ExportedTypesIndex : ScalarIndexExtension<String>(), DataIndexer<String, Void?, FileContent> {
+
+    override fun map(inputData: FileContent): Map<String, Void?> {
+        val file = inputData.psiFile as? PSFile ?: return emptyMap()
+        val module = file.module ?: return emptyMap()
+        val exportedNames = mutableSetOf<String>()
+        module.exportedTypeSynonymDeclarations.mapTo(exportedNames) { it.name }
+        module.exportedDataDeclarations.mapTo(exportedNames) { it.name }
+        module.exportedNewTypeDeclarations.mapTo(exportedNames) { it.name }
+        module.exportedForeignDataDeclarations.mapTo(exportedNames) { it.name }
+        return exportedNames.associateWith { null }
+    }
+
+    override fun getName(): ID<String, Void?> = NAME
+
+    override fun getIndexer() = this
+
+    override fun getKeyDescriptor(): EnumeratorStringDescriptor =
+        EnumeratorStringDescriptor.INSTANCE
+
+    override fun getVersion() = 1
+
+    override fun getInputFilter() =
+        DefaultFileTypeSpecificInputFilter(PSFileType.INSTANCE)
+
+    override fun dependsOnFileContent() = true
+
+    companion object {
+        val NAME =
+            ID.create<String, Void?>("org.purescript.file.ExportedTypesIndex")
+
+        fun filesExportingType(
+            project: Project,
+            typeName: String
+        ): List<PSFile> =
+            ReadAction.compute<List<PSFile>, Throwable> {
+                val allScope = GlobalSearchScope.allScope(project)
+                val files = FileBasedIndex
+                    .getInstance()
+                    .getContainingFiles(NAME, typeName, allScope)
+                files
+                    .map { PsiManager.getInstance(project).findFile(it) }
+                    .filterIsInstance(PSFile::class.java)
+            }
+    }
+
+}

--- a/src/main/java/org/purescript/ide/inspections/PSUnresolvedReferenceInspection.kt
+++ b/src/main/java/org/purescript/ide/inspections/PSUnresolvedReferenceInspection.kt
@@ -58,8 +58,12 @@ class PSUnresolvedReferenceInspection : LocalInspectionTool() {
                 val isClassConstraint = reference.element.parent
                     .siblings(forward = true, withSelf = false)
                     .any { it.text == "=>" }
-
                 if (isClassConstraint) {
+                    return
+                }
+
+                // TODO Workaround to prevent false positives on qualified types
+                if (reference.element.textContains('.')) {
                     return
                 }
 

--- a/src/main/java/org/purescript/ide/inspections/PSUnresolvedReferenceInspection.kt
+++ b/src/main/java/org/purescript/ide/inspections/PSUnresolvedReferenceInspection.kt
@@ -17,6 +17,7 @@ import org.purescript.psi.expression.PSExpressionOperator
 import org.purescript.psi.expression.PSExpressionSymbol
 import org.purescript.psi.imports.PSImportDeclarationImpl
 import org.purescript.psi.imports.PSImportedOperator
+import org.purescript.psi.typeconstructor.PSTypeConstructor
 
 class PSUnresolvedReferenceInspection : LocalInspectionTool() {
     override fun buildVisitor(
@@ -37,11 +38,18 @@ class PSUnresolvedReferenceInspection : LocalInspectionTool() {
                     is PSExpressionIdentifier -> visitReference(element.reference)
                     is PSExpressionSymbol -> visitReference(element.reference)
                     is PSExpressionOperator -> visitReference(element.reference)
+                    is PSTypeConstructor -> visitTypeReference(element.reference)
                 }
             }
 
             private fun visitModuleReference(reference: PsiReference) {
                 if (reference.canonicalText !in PSLanguage.BUILTIN_MODULES) {
+                    visitReference(reference)
+                }
+            }
+
+            private fun visitTypeReference(reference: PsiReference) {
+                if (reference.canonicalText !in PSLanguage.BUILTIN_TYPES) {
                     visitReference(reference)
                 }
             }

--- a/src/main/java/org/purescript/parser/PSElements.kt
+++ b/src/main/java/org/purescript/parser/PSElements.kt
@@ -114,7 +114,7 @@ interface PSElements {
         val ValueDeclaration = PSElementType("ValueDeclaration")
 
         @kotlin.jvm.JvmField
-        val ExternDataDeclaration = PSElementType("ExternDataDeclaration")
+        val ForeignDataDeclaration = PSElementType("ForeignDataDeclaration")
 
         @kotlin.jvm.JvmField
         val ExternInstanceDeclaration = PSElementType("ExternInstanceDeclaration")

--- a/src/main/java/org/purescript/parser/PSParserDefinition.kt
+++ b/src/main/java/org/purescript/parser/PSParserDefinition.kt
@@ -58,7 +58,7 @@ import org.purescript.parser.PSElements.Companion.ExpressionIdentifier
 import org.purescript.parser.PSElements.Companion.ExpressionOperator
 import org.purescript.parser.PSElements.Companion.ExpressionSymbol
 import org.purescript.parser.PSElements.Companion.ExpressionWhere
-import org.purescript.parser.PSElements.Companion.ExternDataDeclaration
+import org.purescript.parser.PSElements.Companion.ForeignDataDeclaration
 import org.purescript.parser.PSElements.Companion.ExternInstanceDeclaration
 import org.purescript.parser.PSElements.Companion.Fixity
 import org.purescript.parser.PSElements.Companion.FixityDeclaration
@@ -245,7 +245,7 @@ class PSParserDefinition : ParserDefinition, PSTokens {
             Signature -> PSSignature(node)
             TypeSynonymDeclaration -> PSTypeSynonymDeclaration(node)
             ValueDeclaration -> PSValueDeclaration(node)
-            ExternDataDeclaration -> PSExternDataDeclarationImpl(node)
+            ForeignDataDeclaration -> PSForeignDataDeclaration(node)
             ExternInstanceDeclaration -> PSExternInstanceDeclarationImpl(node)
             ForeignValueDeclaration -> PSForeignValueDeclaration(node)
             FixityDeclaration -> PSFixityDeclaration(node)

--- a/src/main/java/org/purescript/parser/PureParsecParser.kt
+++ b/src/main/java/org/purescript/parser/PureParsecParser.kt
@@ -297,7 +297,7 @@ class PureParsecParser {
             .then(
                 choice(
                     data
-                        .then(token(PROPER_NAME).`as`(TypeConstructor))
+                        .then(properName)
                         .then(dcolon).then(parseKind)
                         .`as`(ForeignDataDeclaration),
                     `'instance'`

--- a/src/main/java/org/purescript/parser/PureParsecParser.kt
+++ b/src/main/java/org/purescript/parser/PureParsecParser.kt
@@ -49,7 +49,7 @@ import org.purescript.parser.PSElements.Companion.ExpressionIdentifier
 import org.purescript.parser.PSElements.Companion.ExpressionOperator
 import org.purescript.parser.PSElements.Companion.ExpressionSymbol
 import org.purescript.parser.PSElements.Companion.ExpressionWhere
-import org.purescript.parser.PSElements.Companion.ExternDataDeclaration
+import org.purescript.parser.PSElements.Companion.ForeignDataDeclaration
 import org.purescript.parser.PSElements.Companion.GenericIdentifier
 import org.purescript.parser.PSElements.Companion.Guard
 import org.purescript.parser.PSElements.Companion.Identifier
@@ -291,7 +291,7 @@ class PureParsecParser {
                     .then(manyOrEmpty(typeAtom))
             )
         ).then(darrow)
-    private val parseExternDeclaration =
+    private val parseForeignDeclaration =
         token(FOREIGN)
             .then(token(IMPORT))
             .then(
@@ -299,7 +299,7 @@ class PureParsecParser {
                     data
                         .then(token(PROPER_NAME).`as`(TypeConstructor))
                         .then(dcolon).then(parseKind)
-                        .`as`(ExternDataDeclaration),
+                        .`as`(ForeignDataDeclaration),
                     `'instance'`
                         .then(ident).then(dcolon)
                         .then(optional(parseDeps))
@@ -427,7 +427,7 @@ class PureParsecParser {
         (`'type'` + properName + many(typeVarBinding) + eq + type)
             .`as`(TypeSynonymDeclaration),
         (attempt(ident) + many(binderAtom) + guardedDecl).`as`(ValueDeclaration),
-        parseExternDeclaration,
+        parseForeignDeclaration,
         parseFixityDeclaration,
         classDeclaration,
         optional(`'derive'`.then(optional(`'newtype'`)))

--- a/src/main/java/org/purescript/psi/PSExternDataDeclarationImpl.kt
+++ b/src/main/java/org/purescript/psi/PSExternDataDeclarationImpl.kt
@@ -1,5 +1,0 @@
-package org.purescript.psi
-
-import com.intellij.lang.ASTNode
-
-class PSExternDataDeclarationImpl(node: ASTNode) : PSPsiElement(node)

--- a/src/main/java/org/purescript/psi/PSForeignDataDeclaration.kt
+++ b/src/main/java/org/purescript/psi/PSForeignDataDeclaration.kt
@@ -1,0 +1,5 @@
+package org.purescript.psi
+
+import com.intellij.lang.ASTNode
+
+class PSForeignDataDeclaration(node: ASTNode) : PSPsiElement(node)

--- a/src/main/java/org/purescript/psi/PSForeignDataDeclaration.kt
+++ b/src/main/java/org/purescript/psi/PSForeignDataDeclaration.kt
@@ -18,15 +18,11 @@ class PSForeignDataDeclaration(node: ASTNode) :
     internal val properName: PSProperName
         get() = findNotNullChildByClass(PSProperName::class.java)
 
-    override fun setName(name: String): PsiElement? =
-        null
+    override fun setName(name: String): PsiElement? = null
 
-    override fun getNameIdentifier(): PsiElement =
-        properName
+    override fun getNameIdentifier(): PsiElement = properName
 
-    override fun getName(): String =
-        properName.name
+    override fun getName(): String = properName.name
 
-    override fun getTextOffset(): Int =
-        properName.textOffset
+    override fun getTextOffset(): Int = properName.textOffset
 }

--- a/src/main/java/org/purescript/psi/PSForeignDataDeclaration.kt
+++ b/src/main/java/org/purescript/psi/PSForeignDataDeclaration.kt
@@ -3,7 +3,7 @@ package org.purescript.psi
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNameIdentifierOwner
-import org.purescript.psi.typeconstructor.PSTypeConstructor
+import org.purescript.psi.name.PSProperName
 
 /**
  * A foreign data declaration, e.g.
@@ -12,22 +12,21 @@ import org.purescript.psi.typeconstructor.PSTypeConstructor
  * ```
  */
 class PSForeignDataDeclaration(node: ASTNode) :
-        PSPsiElement(node),
-        PsiNameIdentifierOwner {
+    PSPsiElement(node),
+    PsiNameIdentifierOwner {
 
-    internal val typeConstructor: PSTypeConstructor
-        get() = findNotNullChildByClass(PSTypeConstructor::class.java)
+    internal val properName: PSProperName
+        get() = findNotNullChildByClass(PSProperName::class.java)
 
     override fun setName(name: String): PsiElement? =
-            null
+        null
 
-    // TODO This should maybe not be a PSTypeConstructor
     override fun getNameIdentifier(): PsiElement =
-            typeConstructor
+        properName
 
     override fun getName(): String =
-            typeConstructor.name
+        properName.name
 
     override fun getTextOffset(): Int =
-            typeConstructor.textOffset
+        properName.textOffset
 }

--- a/src/main/java/org/purescript/psi/PSForeignDataDeclaration.kt
+++ b/src/main/java/org/purescript/psi/PSForeignDataDeclaration.kt
@@ -1,5 +1,33 @@
 package org.purescript.psi
 
 import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiNameIdentifierOwner
+import org.purescript.psi.typeconstructor.PSTypeConstructor
 
-class PSForeignDataDeclaration(node: ASTNode) : PSPsiElement(node)
+/**
+ * A foreign data declaration, e.g.
+ * ```
+ * foreign import data Effect :: Type -> Type
+ * ```
+ */
+class PSForeignDataDeclaration(node: ASTNode) :
+        PSPsiElement(node),
+        PsiNameIdentifierOwner {
+
+    internal val typeConstructor: PSTypeConstructor
+        get() = findNotNullChildByClass(PSTypeConstructor::class.java)
+
+    override fun setName(name: String): PsiElement? =
+            null
+
+    // TODO This should maybe not be a PSTypeConstructor
+    override fun getNameIdentifier(): PsiElement =
+            typeConstructor
+
+    override fun getName(): String =
+            typeConstructor.name
+
+    override fun getTextOffset(): Int =
+            typeConstructor.textOffset
+}

--- a/src/main/java/org/purescript/psi/PSModule.kt
+++ b/src/main/java/org/purescript/psi/PSModule.kt
@@ -130,6 +130,13 @@ class PSModule(node: ASTNode) :
             findChildrenByClass(PSForeignValueDeclaration::class.java)
 
     /**
+     * @return the [PSForeignDataDeclaration] elements in this module
+     */
+    val foreignDataDeclarations: Array<PSForeignDataDeclaration>
+        get() =
+            findChildrenByClass(PSForeignDataDeclaration::class.java)
+
+    /**
      * @return the [PSNewTypeDeclarationImpl] elements in this module
      */
     val newTypeDeclarations: Array<PSNewTypeDeclarationImpl>
@@ -191,6 +198,17 @@ class PSModule(node: ASTNode) :
             foreignValueDeclarations,
             PSImportDeclarationImpl::importedForeignValueDeclarations,
             PSExportedValue::class.java
+        )
+
+    /**
+     * @return the [PSForeignDataDeclaration] elements that this module exports,
+     * both directly and through re-exported modules
+     */
+    val exportedForeignDataDeclarations: List<PSForeignDataDeclaration>
+        get() = getExportedDeclarations(
+            foreignDataDeclarations,
+            PSImportDeclarationImpl::importedForeignDataDeclarations,
+            PSExportedData::class.java
         )
 
     /**

--- a/src/main/java/org/purescript/psi/PSModule.kt
+++ b/src/main/java/org/purescript/psi/PSModule.kt
@@ -107,7 +107,8 @@ class PSModule(node: ASTNode) :
      * If the export list is null, this module implicitly exports all its members.
      * @return the [PSExportList] in this module, if it exists
      */
-    val exportList: PSExportList? = findChildByClass(PSExportList::class.java)
+    val exportList: PSExportList?
+        get() = findChildByClass(PSExportList::class.java)
 
     /**
      * @return the [PSImportDeclarationImpl] elements in this module

--- a/src/main/java/org/purescript/psi/imports/PSImportDeclarationImpl.kt
+++ b/src/main/java/org/purescript/psi/imports/PSImportDeclarationImpl.kt
@@ -2,10 +2,7 @@ package org.purescript.psi.imports
 
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiNamedElement
-import org.purescript.psi.ModuleReference
-import org.purescript.psi.PSForeignValueDeclaration
-import org.purescript.psi.PSModule
-import org.purescript.psi.PSPsiElement
+import org.purescript.psi.*
 import org.purescript.psi.classes.PSClassDeclaration
 import org.purescript.psi.classes.PSClassMember
 import org.purescript.psi.data.PSDataConstructor
@@ -136,6 +133,15 @@ class PSImportDeclarationImpl(node: ASTNode) : PSPsiElement(node) {
         get() = getImportedDeclarations(
             PSModule::exportedForeignValueDeclarations,
             PSImportedValue::class.java
+        )
+
+    /**
+     * @return the [PSForeignDataDeclaration] elements imported by this declaration
+     */
+    val importedForeignDataDeclarations: List<PSForeignDataDeclaration>
+        get() = getImportedDeclarations(
+            PSModule::exportedForeignDataDeclarations,
+            PSImportedData::class.java
         )
 
     /**

--- a/src/main/java/org/purescript/psi/typeconstructor/TypeConstructorReference.kt
+++ b/src/main/java/org/purescript/psi/typeconstructor/TypeConstructorReference.kt
@@ -27,10 +27,12 @@ class TypeConstructorReference(typeConstructor: PSTypeConstructor) :
             candidates.addAll(module.dataDeclarations)
             candidates.addAll(module.newTypeDeclarations)
             candidates.addAll(module.typeSynonymDeclarations)
+            candidates.addAll(module.foreignDataDeclarations)
             for (importDeclaration in module.importDeclarations) {
                 candidates.addAll(importDeclaration.importedDataDeclarations)
                 candidates.addAll(importDeclaration.importedNewTypeDeclarations)
                 candidates.addAll(importDeclaration.importedTypeSynonymDeclarations)
+                candidates.addAll(importDeclaration.importedForeignDataDeclarations)
             }
             return candidates
         }

--- a/src/main/java/org/purescript/psi/typeconstructor/TypeConstructorReference.kt
+++ b/src/main/java/org/purescript/psi/typeconstructor/TypeConstructorReference.kt
@@ -1,9 +1,15 @@
 package org.purescript.psi.typeconstructor
 
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.LocalQuickFixProvider
 import com.intellij.psi.PsiNamedElement
 import com.intellij.psi.PsiReferenceBase
+import org.purescript.file.ExportedConstructorsIndex
+import org.purescript.file.ExportedTypesIndex
+import org.purescript.psi.expression.ImportQuickFix
 
 class TypeConstructorReference(typeConstructor: PSTypeConstructor) :
+    LocalQuickFixProvider,
     PsiReferenceBase<PSTypeConstructor>(
         typeConstructor,
         typeConstructor.textRangeInParent,
@@ -36,4 +42,15 @@ class TypeConstructorReference(typeConstructor: PSTypeConstructor) :
             }
             return candidates
         }
+
+    override fun getQuickFixes(): Array<LocalQuickFix> {
+        return importCandidates
+            .map { ImportQuickFix(it) }
+            .toTypedArray()
+    }
+
+    private val importCandidates: List<String>
+        get() = ExportedTypesIndex
+            .filesExportingType(element.project, element.name)
+            .mapNotNull { it.module?.name }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -87,6 +87,7 @@
     <fileBasedIndex implementation="org.purescript.file.ModuleNameIndex" />
     <fileBasedIndex implementation="org.purescript.file.ExportedConstructorsIndex" />
     <fileBasedIndex implementation="org.purescript.file.ExportedValuesIndex" />
+    <fileBasedIndex implementation="org.purescript.file.ExportedTypesIndex" />
     <fileBasedIndex implementation="org.purescript.file.ImportedModuleIndex" />
   </extensions>
 

--- a/src/test/java/org/purescript/accessors.kt
+++ b/src/test/java/org/purescript/accessors.kt
@@ -4,6 +4,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiRecursiveElementVisitor
 import org.purescript.file.PSFile
+import org.purescript.psi.PSForeignDataDeclaration
 import org.purescript.psi.PSForeignValueDeclaration
 import org.purescript.psi.PSModule
 import org.purescript.psi.declaration.PSValueDeclaration
@@ -179,14 +180,23 @@ fun PsiFile.getClassMember(): PSClassMember =
 fun PsiFile.getClassConstraint(): PSClassConstraint =
     getClassDeclaration().classConstraints.single()
 
+fun PsiFile.getTypeConstructors(): List<PSTypeConstructor> =
+    collectDescendantsOfType()
+
 fun PsiFile.getTypeConstructor(): PSTypeConstructor =
-    collectDescendantsOfType<PSTypeConstructor>().single()
+    getTypeConstructors().single()
 
 fun PsiFile.getTypeSynonymDeclarations(): Array<PSTypeSynonymDeclaration> =
     getModule().typeSynonymDeclarations
 
 fun PsiFile.getTypeSynonymDeclaration(): PSTypeSynonymDeclaration =
     getTypeSynonymDeclarations().single()
+
+fun PsiFile.getForeignDataDeclarations(): Array<PSForeignDataDeclaration> =
+    getModule().foreignDataDeclarations
+
+fun PsiFile.getForeignDataDeclaration(): PSForeignDataDeclaration =
+    getForeignDataDeclarations().single()
 
 fun PsiFile.getExpressionConstructors(): List<PSExpressionConstructor> =
     collectDescendantsOfType()

--- a/src/test/java/org/purescript/ide/inspections/PSUnresolvedReferenceInspectionTest.kt
+++ b/src/test/java/org/purescript/ide/inspections/PSUnresolvedReferenceInspectionTest.kt
@@ -705,4 +705,19 @@ class PSUnresolvedReferenceInspectionTest : BasePlatformTestCase() {
         myFixture.enableInspections(PSUnresolvedReferenceInspection())
         myFixture.checkHighlighting()
     }
+
+    fun `test does not report resolved class constraints`() {
+        myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo where
+                class Show a where
+                    show :: a -> String
+                f :: forall a. Show a => a -> String
+                f a = show a
+            """.trimIndent()
+        )
+        myFixture.enableInspections(PSUnresolvedReferenceInspection())
+        myFixture.checkHighlighting()
+    }
 }

--- a/src/test/java/org/purescript/ide/inspections/PSUnresolvedReferenceInspectionTest.kt
+++ b/src/test/java/org/purescript/ide/inspections/PSUnresolvedReferenceInspectionTest.kt
@@ -204,7 +204,7 @@ class PSUnresolvedReferenceInspectionTest : BasePlatformTestCase() {
             """
             module Foo where
             class Box a where
-                map :: forall a b. (a -> b) -> Box a -> Box b 
+                map :: forall a b. (a -> b) -> a -> b 
             f = map
             """.trimIndent()
         )
@@ -658,4 +658,51 @@ class PSUnresolvedReferenceInspectionTest : BasePlatformTestCase() {
         myFixture.checkHighlighting()
     }
 
+    fun `test reports unresolved type constructor`() {
+        myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo where
+                f :: <error descr="Cannot resolve symbol 'Bar'">Bar</error>
+                f = 3
+            """.trimIndent()
+        )
+        myFixture.enableInspections(PSUnresolvedReferenceInspection())
+        myFixture.checkHighlighting()
+    }
+
+    fun `test does not report locally resolved type constructor`() {
+        myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo where
+                type Bar = Int
+                f :: Bar
+                f = 3
+            """.trimIndent()
+        )
+        myFixture.enableInspections(PSUnresolvedReferenceInspection())
+        myFixture.checkHighlighting()
+    }
+
+    fun `test does not report imported resolved type constructor`() {
+        myFixture.configureByText(
+            "Bar.purs",
+            """
+                module Bar where
+                foreign import data Qux :: Type
+            """.trimIndent()
+        )
+        myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo where
+                import Bar (Qux)
+                f :: Qux
+                f = 3
+            """.trimIndent()
+        )
+        myFixture.enableInspections(PSUnresolvedReferenceInspection())
+        myFixture.checkHighlighting()
+    }
 }

--- a/src/test/java/org/purescript/psi/expression/ImportQuickFixTest.kt
+++ b/src/test/java/org/purescript/psi/expression/ImportQuickFixTest.kt
@@ -126,4 +126,28 @@ class ImportQuickFixTest : BasePlatformTestCase() {
 
         assertEquals("Bar", file.getImportDeclarations().single().name)
     }
+
+    fun `test imports type constructor`() {
+        myFixture.configureByText(
+            "Bar.purs",
+            """
+                module Bar where
+                foreign import data Bar :: Type
+            """.trimIndent()
+        )
+        val file = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo where
+                f :: Bar
+            """.trimIndent()
+        )
+        myFixture.enableInspections(PSUnresolvedReferenceInspection())
+        val action = myFixture.getAllQuickFixes("Foo.purs").single()
+        myFixture.launchAction(action)
+        val importDeclaration = file.getImportDeclaration()
+
+        assertEquals("Import Bar", action.familyName)
+        assertEquals("Bar", importDeclaration.name)
+    }
 }

--- a/src/test/java/org/purescript/psi/typeconstructor/TypeConstructorReferenceTest.kt
+++ b/src/test/java/org/purescript/psi/typeconstructor/TypeConstructorReferenceTest.kt
@@ -1,10 +1,8 @@
 package org.purescript.psi.typeconstructor
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import org.purescript.getDataDeclaration
-import org.purescript.getNewTypeDeclaration
-import org.purescript.getTypeConstructor
-import org.purescript.getTypeSynonymDeclaration
+import junit.framework.TestCase
+import org.purescript.*
 
 class TypeConstructorReferenceTest : BasePlatformTestCase() {
 
@@ -254,7 +252,7 @@ class TypeConstructorReferenceTest : BasePlatformTestCase() {
                 """.trimIndent()
         )
         val usageInfo = myFixture.testFindUsages("Main.purs")
-        
+
         assertEquals(2, usageInfo.size)
     }
 
@@ -275,6 +273,100 @@ class TypeConstructorReferenceTest : BasePlatformTestCase() {
             """.trimIndent()
         ).getTypeConstructor()
         val usageInfo = myFixture.findUsages(typeSynonymDeclaration).single()
+
+        assertEquals(typeConstructor, usageInfo.element)
+    }
+
+    fun `test resolves local foreign data declarations`() {
+        val file = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo where
+                foreign import data Bar :: Type
+                q :: Bar
+            """.trimIndent()
+        )
+        val foreignDataDeclaration = file.getForeignDataDeclaration()
+        val typeConstructor = file.getTypeConstructors()[1]
+
+        assertEquals("Bar", typeConstructor.name)
+        assertEquals(foreignDataDeclaration, typeConstructor.reference.resolve())
+    }
+
+    fun `test resolves imported foreign data declarations`() {
+        val foreignDataDeclaration = myFixture.configureByText(
+            "Bar.purs",
+            """
+                module Bar where
+                foreign import data Qux :: Type
+            """.trimIndent()
+        ).getForeignDataDeclaration()
+        val typeConstructor = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo where
+                import Bar
+                a :: Qux
+            """.trimIndent()
+        ).getTypeConstructor()
+
+        assertEquals(foreignDataDeclaration, typeConstructor.reference.resolve())
+    }
+
+    fun `test completes foreign data declarations`() {
+        myFixture.configureByText(
+            "Bar.purs",
+            """
+                module Bar where
+                foreign import data Qux :: Type
+            """.trimIndent()
+        )
+        myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo where
+                import Bar
+                foreign import data Bum :: Type
+                a :: <caret>
+            """.trimIndent()
+        )
+
+        myFixture.testCompletionVariants("Foo.purs", "Qux", "Bum")
+    }
+
+    fun `test finds usages from local foreign data declarations`() {
+        myFixture.configureByText(
+            "Main.purs",
+            """
+                module Data where
+                foreign import data B :: Type
+                foreign import data <caret>A :: Type
+                func :: A -> A
+                func a = a
+                """.trimIndent()
+        )
+        val usageInfo = myFixture.testFindUsages("Main.purs")
+
+        assertEquals(2, usageInfo.size)
+    }
+
+    fun `test finds usages from imported foreign data declarations`() {
+        val foreignDataDeclaration = myFixture.configureByText(
+            "Bar.purs",
+            """
+                module Bar where
+                foreign import data Qux :: Type
+            """.trimIndent()
+        ).getForeignDataDeclaration()
+        val typeConstructor = myFixture.configureByText(
+            "Foo.purs",
+            """
+                module Foo where
+                import Bar
+                a :: Qux
+            """.trimIndent()
+        ).getTypeConstructor()
+        val usageInfo = myFixture.findUsages(foreignDataDeclaration).single()
 
         assertEquals(typeConstructor, usageInfo.element)
     }

--- a/src/test/java/org/purescript/psi/typeconstructor/TypeConstructorReferenceTest.kt
+++ b/src/test/java/org/purescript/psi/typeconstructor/TypeConstructorReferenceTest.kt
@@ -248,7 +248,7 @@ class TypeConstructorReferenceTest : BasePlatformTestCase() {
                 type <caret>A = Int
                 func :: A -> A
                 func a = a
-                """.trimIndent()
+            """.trimIndent()
         )
         val usageInfo = myFixture.testFindUsages("Main.purs")
 
@@ -342,7 +342,7 @@ class TypeConstructorReferenceTest : BasePlatformTestCase() {
                 foreign import data <caret>A :: Type
                 func :: A -> A
                 func a = a
-                """.trimIndent()
+            """.trimIndent()
         )
         val usageInfo = myFixture.testFindUsages("Main.purs")
 

--- a/src/test/java/org/purescript/psi/typeconstructor/TypeConstructorReferenceTest.kt
+++ b/src/test/java/org/purescript/psi/typeconstructor/TypeConstructorReferenceTest.kt
@@ -1,7 +1,6 @@
 package org.purescript.psi.typeconstructor
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import junit.framework.TestCase
 import org.purescript.*
 
 class TypeConstructorReferenceTest : BasePlatformTestCase() {

--- a/test-data/parser/FunWithFunDeps.txt
+++ b/test-data/parser/FunWithFunDeps.txt
@@ -366,7 +366,7 @@ Purescript File
     PsiElement(import)('import')
     PSForeignDataDeclaration(ForeignDataDeclaration)
       PsiElement(data)('data')
-      PSTypeConstructor(TypeConstructor)
+      PSProperName(ProperName)
         PsiElement(proper name)('FVect')
       PsiElement(::)('::')
       PSFunKindImpl(FunKind)

--- a/test-data/parser/FunWithFunDeps.txt
+++ b/test-data/parser/FunWithFunDeps.txt
@@ -364,7 +364,7 @@ Purescript File
           PsiElement(identifier)('s')
     PsiElement(foreign)('foreign')
     PsiElement(import)('import')
-    PSExternDataDeclarationImpl(ExternDataDeclaration)
+    PSForeignDataDeclaration(ForeignDataDeclaration)
       PsiElement(data)('data')
       PSTypeConstructor(TypeConstructor)
         PsiElement(proper name)('FVect')

--- a/test-data/parser/MutRec2.txt
+++ b/test-data/parser/MutRec2.txt
@@ -55,7 +55,7 @@ Purescript File
     PsiElement(import)('import')
     PSForeignDataDeclaration(ForeignDataDeclaration)
       PsiElement(data)('data')
-      PSTypeConstructor(TypeConstructor)
+      PSProperName(ProperName)
         PsiElement(proper name)('S')
       PsiElement(::)('::')
       PSFunKindImpl(FunKind)

--- a/test-data/parser/MutRec2.txt
+++ b/test-data/parser/MutRec2.txt
@@ -53,7 +53,7 @@ Purescript File
                   PsiElement(proper name)('A')
     PsiElement(foreign)('foreign')
     PsiElement(import)('import')
-    PSExternDataDeclarationImpl(ExternDataDeclaration)
+    PSForeignDataDeclaration(ForeignDataDeclaration)
       PsiElement(data)('data')
       PSTypeConstructor(TypeConstructor)
         PsiElement(proper name)('S')

--- a/test-data/parser/MutRec3.txt
+++ b/test-data/parser/MutRec3.txt
@@ -55,7 +55,7 @@ Purescript File
     PsiElement(import)('import')
     PSForeignDataDeclaration(ForeignDataDeclaration)
       PsiElement(data)('data')
-      PSTypeConstructor(TypeConstructor)
+      PSProperName(ProperName)
         PsiElement(proper name)('S')
       PsiElement(::)('::')
       PSFunKindImpl(FunKind)

--- a/test-data/parser/MutRec3.txt
+++ b/test-data/parser/MutRec3.txt
@@ -53,7 +53,7 @@ Purescript File
                   PsiElement(proper name)('A')
     PsiElement(foreign)('foreign')
     PsiElement(import)('import')
-    PSExternDataDeclarationImpl(ExternDataDeclaration)
+    PSForeignDataDeclaration(ForeignDataDeclaration)
       PsiElement(data)('data')
       PSTypeConstructor(TypeConstructor)
         PsiElement(proper name)('S')

--- a/test-data/parser/PrimedTypeName.txt
+++ b/test-data/parser/PrimedTypeName.txt
@@ -84,7 +84,7 @@ Purescript File
     PsiElement(import)('import')
     PSForeignDataDeclaration(ForeignDataDeclaration)
       PsiElement(data)('data')
-      PSTypeConstructor(TypeConstructor)
+      PSProperName(ProperName)
         PsiElement(proper name)('T'''')
       PsiElement(::)('∷')
       PSFunKindImpl(FunKind)

--- a/test-data/parser/PrimedTypeName.txt
+++ b/test-data/parser/PrimedTypeName.txt
@@ -82,7 +82,7 @@ Purescript File
             PsiElement(proper name)('TP')
     PsiElement(foreign)('foreign')
     PsiElement(import)('import')
-    PSExternDataDeclarationImpl(ExternDataDeclaration)
+    PSForeignDataDeclaration(ForeignDataDeclaration)
       PsiElement(data)('data')
       PSTypeConstructor(TypeConstructor)
         PsiElement(proper name)('T'''')


### PR DESCRIPTION
**Depends on #252**

This PR contains a couple of workarounds for cases where we incorrectly identify elements as type constructors, when they really are class constraints or kinds. I prefer these workarounds compared to having false positives on the inspection, but they should be removed as we improve the parser.


https://user-images.githubusercontent.com/5345337/117550999-a146c800-b043-11eb-8012-a06d74f8768c.mov

