### PR TITLE
Clean up path manipulation

### DIFF
--- a/src/main/kotlin/org/purescript/ide/purs/PursIdeRebuildExternalAnnotator.kt
+++ b/src/main/kotlin/org/purescript/ide/purs/PursIdeRebuildExternalAnnotator.kt
@@ -38,8 +38,7 @@ class PursIdeRebuildExternalAnnotator : ExternalAnnotator<PsiFile, Response>() {
         )
         return try {
             val json = gson.fromJson(output, Response::class.java)
-            @Suppress("SENSELESS_COMPARISON")
-            if (json.resultType != null && json.resultType in listOf("success", "error")) {
+            if (json?.resultType in listOf("success", "error")) {
                 json
             } else {
                 null

--- a/src/main/kotlin/org/purescript/ide/purs/PursIdeRebuildExternalAnnotator.kt
+++ b/src/main/kotlin/org/purescript/ide/purs/PursIdeRebuildExternalAnnotator.kt
@@ -7,7 +7,6 @@ import com.intellij.execution.util.ExecUtil
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.ExternalAnnotator
 import com.intellij.lang.annotation.HighlightSeverity
-import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.util.SystemInfo.isWindows
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
@@ -53,24 +52,21 @@ class PursIdeRebuildExternalAnnotator : ExternalAnnotator<PsiFile, Response>() {
     }
 
     private fun getPursPath(file: PsiFile): Path? {
-        val path: Path = file.virtualFile.toNioPath()
-        val projectRoot = sequence<Path> {
-            var tmp = path
+        val nodeModules: Path = sequence<Path> {
+            var tmp = file.virtualFile.toNioPath()
             while (tmp.parent != null) {
                 yield(tmp.parent)
                 tmp = tmp.parent
             }
-        }.firstOrNull() { (it / "node_modules").exists() }
-
-        if (projectRoot != null) {
-            val binDir = projectRoot / "node_modules" / ".bin"
-            return if (isWindows) {
-                binDir / "purs.cmd"
-            } else {
-                binDir / "purs"
-            }
         }
-        return null
+            .map { it / "node_modules" }
+            .firstOrNull() { it.exists() }
+            ?: return null
+        val binDir = nodeModules / ".bin"
+        return when {
+            isWindows -> binDir / "purs.cmd"
+            else -> binDir / "purs"
+        }
     }
 
     override fun apply(


### PR DESCRIPTION
when trying to publish the changes it somehow did not work so i tried to simplify the code to see if it will be releasable.
```
> Task :compileKotlin FAILED
2 actionable tasks: 2 executed
public inline operator fun BigDecimal.div(other: BigDecimal): BigDecimal defined in kotlin
public inline operator fun BigInteger.div(other: BigInteger): BigInteger defined in kotlin
e: /home/runner/work/intellij-purescript/intellij-purescript/src/main/kotlin/org/purescript/ide/purs/PursIdeRebuildExternalAnnotator.kt: (66, 38): Unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
public inline operator fun BigDecimal.div(other: BigDecimal): BigDecimal defined in kotlin
public inline operator fun BigInteger.div(other: BigInteger): BigInteger defined in kotlin
```