### PR TITLE
Start purs ide server

### DIFF
--- a/src/main/kotlin/org/purescript/ide/purs/Purs.kt
+++ b/src/main/kotlin/org/purescript/ide/purs/Purs.kt
@@ -1,0 +1,27 @@
+package org.purescript.ide.purs
+
+import com.intellij.openapi.util.SystemInfo
+import java.io.File
+import java.nio.file.Path
+
+class Purs {
+    fun nodeModulesVersion(root: Path?): Path? {
+        val sequence = sequence<Path> {
+            var tmp = root
+            while (tmp != null) {
+                yield(tmp)
+                tmp = tmp.parent
+            }
+        }
+        val nodeModules = sequence
+            .map { it.resolve("node_modules") }
+            .firstOrNull { it.toFile().exists() }
+            ?: return null
+        val binDir = nodeModules.resolve(".bin")
+        return when {
+            SystemInfo.isWindows -> binDir.resolve("purs.cmd")
+            else -> binDir.resolve("purs")
+        }
+
+    }
+}

--- a/src/main/kotlin/org/purescript/ide/purs/PursIdeRebuildExternalAnnotator.kt
+++ b/src/main/kotlin/org/purescript/ide/purs/PursIdeRebuildExternalAnnotator.kt
@@ -55,9 +55,9 @@ class PursIdeRebuildExternalAnnotator : ExternalAnnotator<PsiFile, Response>() {
     }
 
     override fun apply(
-        file: @NotNull PsiFile,
+        file: PsiFile,
         annotationResult: Response,
-        holder: @NotNull AnnotationHolder
+        holder: AnnotationHolder
     ) {
         val documentManager = PsiDocumentManager.getInstance(file.project)
         val document = documentManager.getDocument(file) ?: return

--- a/src/main/kotlin/org/purescript/ide/purs/PursIdeRebuildExternalAnnotator.kt
+++ b/src/main/kotlin/org/purescript/ide/purs/PursIdeRebuildExternalAnnotator.kt
@@ -1,5 +1,6 @@
 package org.purescript.ide.purs
 
+
 import com.google.gson.Gson
 import com.google.gson.JsonSyntaxException
 import com.intellij.execution.configurations.GeneralCommandLine
@@ -8,23 +9,22 @@ import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.ExternalAnnotator
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.project.guessProjectDir
-import com.intellij.openapi.util.SystemInfo.isWindows
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
-
-
-import org.jetbrains.annotations.NotNull
 import java.io.File
-import java.nio.file.Path
 
 class PursIdeRebuildExternalAnnotator : ExternalAnnotator<PsiFile, Response>() {
     override fun collectInformation(file: PsiFile) = file
 
     override fun doAnnotate(file: PsiFile): Response? {
+
         // without a project dir we don't know where to build the file
         val projectDir = file.project.guessProjectDir() ?: return null
         val rootDir = projectDir.toNioPath()
-        val pursBin = Purs().nodeModulesVersion(rootDir)
+
+        // without a purs bin path we can't annotate with it
+        val pursBin = Purs().nodeModulesVersion(rootDir) ?: return null
+
         val gson = Gson()
         val tempFile: File =
             File.createTempFile("purescript-intellij", file.name)

--- a/src/main/kotlin/org/purescript/ide/purs/StartupActivity.kt
+++ b/src/main/kotlin/org/purescript/ide/purs/StartupActivity.kt
@@ -2,24 +2,22 @@ package org.purescript.ide.purs
 
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.CapturingProcessHandler
-import com.intellij.execution.process.OSProcessUtil
-import com.intellij.execution.process.OSProcessUtil.killProcessTree
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.startup.StartupActivity
-import com.intellij.openapi.util.SystemInfo
-import java.io.File
-import java.nio.file.Path
-import java.util.concurrent.TimeUnit
 
 class StartupActivity : StartupActivity.Background {
     override fun runActivity(project: Project) {
+
         // without a project dir we don't know where to start the server
         val projectDir = project.guessProjectDir() ?: return
         val rootDir = projectDir.toNioPath()
-        val pursBin = Purs().nodeModulesVersion(rootDir)
+
+        // without a purs bin path we can't annotate with it
+        val pursBin = Purs().nodeModulesVersion(rootDir) ?: return
+
         val command = GeneralCommandLine(pursBin.toString(), "ide", "server")
             .withWorkDirectory(rootDir.toFile())
         val task = object : Task.Backgroundable(

--- a/src/main/kotlin/org/purescript/ide/purs/StartupActivity.kt
+++ b/src/main/kotlin/org/purescript/ide/purs/StartupActivity.kt
@@ -10,16 +10,18 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.startup.StartupActivity
 import com.intellij.openapi.util.SystemInfo
+import java.io.File
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 
 class StartupActivity : StartupActivity.Background {
     override fun runActivity(project: Project) {
-        val pursBin = getPursPath(project) ?: return
-        // node_modules/.bin/purs <- 3 parents
-        val rootDir = pursBin.parent.parent.parent.toFile()
+        // without a project dir we don't know where to start the server
+        val projectDir = project.guessProjectDir() ?: return
+        val rootDir = projectDir.toNioPath()
+        val pursBin = Purs().nodeModulesVersion(rootDir)
         val command = GeneralCommandLine(pursBin.toString(), "ide", "server")
-            .withWorkDirectory(rootDir)
+            .withWorkDirectory(rootDir.toFile())
         val task = object : Task.Backgroundable(
             project,
             "purs ide server for " + project.name,
@@ -32,24 +34,5 @@ class StartupActivity : StartupActivity.Background {
 
         }
         task.queue()
-    }
-
-    private fun getPursPath(project: Project): Path? {
-        val sequence = sequence<Path> {
-            var tmp = project.guessProjectDir()?.toNioPath()
-            while (tmp != null) {
-                yield(tmp)
-                tmp = tmp.parent
-            }
-        }
-        val nodeModules = sequence
-            .map { it.resolve("node_modules") }
-            .firstOrNull { it.toFile().exists() }
-            ?: return null
-        val binDir = nodeModules.resolve(".bin")
-        return when {
-            SystemInfo.isWindows -> binDir.resolve("purs.cmd")
-            else -> binDir.resolve("purs")
-        }
     }
 }

--- a/src/main/kotlin/org/purescript/ide/purs/StartupActivity.kt
+++ b/src/main/kotlin/org/purescript/ide/purs/StartupActivity.kt
@@ -2,6 +2,7 @@ package org.purescript.ide.purs
 
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.CapturingProcessHandler
+import com.intellij.ide.plugins.PluginManagerCore.isUnitTestMode
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
@@ -10,6 +11,8 @@ import com.intellij.openapi.startup.StartupActivity
 
 class StartupActivity : StartupActivity.Background {
     override fun runActivity(project: Project) {
+        // don't start the activity under test, it will hang if it doese
+        if (isUnitTestMode) return
 
         // without a project dir we don't know where to start the server
         val projectDir = project.guessProjectDir() ?: return

--- a/src/main/kotlin/org/purescript/ide/purs/StartupActivity.kt
+++ b/src/main/kotlin/org/purescript/ide/purs/StartupActivity.kt
@@ -1,0 +1,55 @@
+package org.purescript.ide.purs
+
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.CapturingProcessHandler
+import com.intellij.execution.process.OSProcessUtil
+import com.intellij.execution.process.OSProcessUtil.killProcessTree
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.guessProjectDir
+import com.intellij.openapi.startup.StartupActivity
+import com.intellij.openapi.util.SystemInfo
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+
+class StartupActivity : StartupActivity.Background {
+    override fun runActivity(project: Project) {
+        val pursBin = getPursPath(project) ?: return
+        // node_modules/.bin/purs <- 3 parents
+        val rootDir = pursBin.parent.parent.parent.toFile()
+        val command = GeneralCommandLine(pursBin.toString(), "ide", "server")
+            .withWorkDirectory(rootDir)
+        val task = object : Task.Backgroundable(
+            project,
+            "purs ide server for " + project.name,
+            true
+        ) {
+            override fun run(indicator: ProgressIndicator) {
+                CapturingProcessHandler(command)
+                    .runProcessWithProgressIndicator(indicator)
+            }
+
+        }
+        task.queue()
+    }
+
+    private fun getPursPath(project: Project): Path? {
+        val sequence = sequence<Path> {
+            var tmp = project.guessProjectDir()?.toNioPath()
+            while (tmp != null) {
+                yield(tmp)
+                tmp = tmp.parent
+            }
+        }
+        val nodeModules = sequence
+            .map { it.resolve("node_modules") }
+            .firstOrNull { it.toFile().exists() }
+            ?: return null
+        val binDir = nodeModules.resolve(".bin")
+        return when {
+            SystemInfo.isWindows -> binDir.resolve("purs.cmd")
+            else -> binDir.resolve("purs")
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -90,7 +90,7 @@
             enabledByDefault="true" level="ERROR"
             implementationClass="org.purescript.ide.inspections.PSUnresolvedReferenceInspection"
     />
-
+    <!-- purs ide -->
     <localInspection
         language="Purescript"
         groupName="Purescript"
@@ -104,6 +104,9 @@
     <externalAnnotator
             language="Purescript"
             implementationClass="org.purescript.ide.purs.PursIdeRebuildExternalAnnotator"
+    />
+    <postStartupActivity
+        implementation="org.purescript.ide.purs.StartupActivity"
     />
 
     <!-- Formatting -->


### PR DESCRIPTION

https://user-images.githubusercontent.com/72190/130360678-c3a9c596-9ee9-4494-ac4c-599b8a851692.mp4

The plugin now starts the purs ide server when a project is open and it can find the purse executable in the node modules bin folder.

This together with the old feature of the rebuild annotation it will now use that server if it successfully started without you needing to start one by hand.

If you don't want the server to run you can stop it as any other process down at the background processes bar. 