### PR TITLE
Move rebuild message from "name" to tooltip

### DIFF
--- a/src/main/kotlin/org/purescript/ide/purs/PursIdeRebuildExternalAnnotator.kt
+++ b/src/main/kotlin/org/purescript/ide/purs/PursIdeRebuildExternalAnnotator.kt
@@ -68,7 +68,8 @@ class PursIdeRebuildExternalAnnotator : ExternalAnnotator<PsiFile, Response>() {
         for (result in annotationResult.result) {
             val textRange = result.position.textRange(document)
             val annotationBuilder = holder
-                .newAnnotation(severity, result.message)
+                .newAnnotation(severity, "Purs ide rebuild")
+                .tooltip(result.message)
                 .range(textRange)
                 .needsUpdateOnTyping()
             if (result.suggestion != null) {


### PR DESCRIPTION
This will make sure that the whitespace layout will be correct.