### PR TITLE
Refer to global purs if not installed in project

### DIFF
--- a/src/main/kotlin/org/purescript/ide/purs/Purs.kt
+++ b/src/main/kotlin/org/purescript/ide/purs/Purs.kt
@@ -56,7 +56,7 @@ class Purs {
                     if (isWindows) {
                         it.resolve("purs.cmd")
                     } else {
-                        it.resolve("purs")
+                        it.resolve("purescript/purs.bin")
                     }
                 }.firstOrNull { it.toFile().exists() }
         }

--- a/src/main/kotlin/org/purescript/ide/purs/Purs.kt
+++ b/src/main/kotlin/org/purescript/ide/purs/Purs.kt
@@ -1,27 +1,78 @@
 package org.purescript.ide.purs
 
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.util.SystemInfo
-import java.io.File
 import java.nio.file.Path
+import java.util.concurrent.TimeUnit
 
 class Purs {
-    fun nodeModulesVersion(root: Path?): Path? {
-        val sequence = sequence<Path> {
-            var tmp = root
-            while (tmp != null) {
-                yield(tmp)
-                tmp = tmp.parent
+    companion object {
+        private val linuxGetNPMRootShellCmd = listOf<String>("/bin/bash", "-c", "npm -g root")
+        private val windowsGetNPMRootShellCmd = listOf<String>("cmd", "/c", "npm -g root")
+        private val log = logger<Purs>()
+        private var pursCmd: Path? = null
+
+        fun nodeModulesVersion(project: Project): Path? {
+            if (pursCmd == null) {
+                val projectDir = project.guessProjectDir() ?: return null
+                val rootDir = projectDir.toNioPath()
+
+                val sequence: Sequence<Path> = sequence {
+                    var localPath: Path? = rootDir
+                    while (localPath != null) {
+                        yield(localPath)
+                        localPath = localPath.parent
+                    }
+                }
+                pursCmd = extractPursCmd(sequence, "node_modules/.bin", SystemInfo.isWindows)
+
+                if (pursCmd == null) {
+                    val globalSequence = sequence<Path> {
+                        var globalPath: Path? = npmGlobalModulesDir()
+                        while (globalPath != null) {
+                            yield(globalPath)
+                            globalPath = globalPath.parent
+                        }
+                    }
+                    pursCmd = extractPursCmd(globalSequence, "./", SystemInfo.isWindows)
+                }
             }
-        }
-        val nodeModules = sequence
-            .map { it.resolve("node_modules") }
-            .firstOrNull { it.toFile().exists() }
-            ?: return null
-        val binDir = nodeModules.resolve(".bin")
-        return when {
-            SystemInfo.isWindows -> binDir.resolve("purs.cmd")
-            else -> binDir.resolve("purs")
+
+            if (log.isDebugEnabled) {
+                if (pursCmd == null) {
+                    log.debug("purs is not found")
+                } else {
+                    log.debug("purs is found at $pursCmd")
+                }
+            }
+            return pursCmd
         }
 
+        private fun extractPursCmd(sequence: Sequence<Path>, pursExecutablePathStr: String, isWindows: Boolean): Path? {
+            return sequence.map { it.resolve(pursExecutablePathStr) }
+                .filter { it.toFile().exists() }.map {
+                    if (isWindows) {
+                        it.resolve("purs.cmd")
+                    } else {
+                        it.resolve("purs")
+                    }
+                }.firstOrNull { it.toFile().exists() }
+        }
+
+        fun npmGlobalModulesDir(): Path {
+            val npmCmd = if (SystemInfo.isWindows) windowsGetNPMRootShellCmd
+            else linuxGetNPMRootShellCmd
+
+            val npmProc = ProcessBuilder(npmCmd).redirectError(ProcessBuilder.Redirect.PIPE)
+                .redirectOutput(ProcessBuilder.Redirect.PIPE).start()
+
+            npmProc.waitFor(4, TimeUnit.SECONDS)
+            val rawPath: String? = npmProc.inputStream.bufferedReader().readLine()
+            return if (rawPath != null && rawPath.isNotEmpty()) {
+                Path.of(rawPath)
+            } else Path.of("/")
+        }
     }
 }

--- a/src/main/kotlin/org/purescript/ide/purs/PursIdeAddClauseQuickFix.kt
+++ b/src/main/kotlin/org/purescript/ide/purs/PursIdeAddClauseQuickFix.kt
@@ -1,25 +1,20 @@
 package org.purescript.ide.purs
 
 import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
 import com.intellij.codeInsight.intention.IntentionAction
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.util.ExecUtil
 import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.application.runUndoTransparentWriteAction
-import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.progress.Task
 import com.intellij.openapi.progress.runBackgroundableTask
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.util.Iconable
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
 import org.purescript.icons.PSIcons
 import java.io.File
-
 
 class PursIdeAddClauseQuickFix(private val textRange: TextRange) : IntentionAction, Iconable {
     data class Response(val result: List<String>, val resultType: String) {}
@@ -37,12 +32,8 @@ class PursIdeAddClauseQuickFix(private val textRange: TextRange) : IntentionActi
             PsiDocumentManager.getInstance(file.project).getDocument(file)
                 ?: return
 
-        // without a project dir we don't know where to build the file
-        val projectDir = file.project.guessProjectDir() ?: return
-        val rootDir = projectDir.toNioPath()
-
         // without a purs bin path we can't annotate with it
-        val pursBin = Purs().nodeModulesVersion(rootDir) ?: return
+        val pursBin = Purs.nodeModulesVersion(file.project) ?: return
 
         val gson = Gson()
         val tempFile: File =
@@ -75,5 +66,4 @@ class PursIdeAddClauseQuickFix(private val textRange: TextRange) : IntentionActi
     }
 
     override fun getIcon(flags: Int) = PSIcons.FILE
-
 }

--- a/src/main/kotlin/org/purescript/ide/purs/PursIdeRebuildExternalAnnotator.kt
+++ b/src/main/kotlin/org/purescript/ide/purs/PursIdeRebuildExternalAnnotator.kt
@@ -8,7 +8,6 @@ import com.intellij.execution.util.ExecUtil
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.ExternalAnnotator
 import com.intellij.lang.annotation.HighlightSeverity
-import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
@@ -19,12 +18,8 @@ class PursIdeRebuildExternalAnnotator : ExternalAnnotator<PsiFile, Response>() {
 
     override fun doAnnotate(file: PsiFile): Response? {
 
-        // without a project dir we don't know where to build the file
-        val projectDir = file.project.guessProjectDir() ?: return null
-        val rootDir = projectDir.toNioPath()
-
         // without a purs bin path we can't annotate with it
-        val pursBin = Purs().nodeModulesVersion(rootDir) ?: return null
+        val pursBin = Purs.nodeModulesVersion(file.project) ?: return null
 
         val gson = Gson()
         val tempFile: File =
@@ -98,9 +93,7 @@ class PursIdeRebuildExternalAnnotator : ExternalAnnotator<PsiFile, Response>() {
         }
     }
 
-
     override fun getPairedBatchInspectionShortName(): String {
         return PursIdeRebuildInspection.SHORT_NAME
     }
-
 }

--- a/src/main/kotlin/org/purescript/ide/purs/StartupActivity.kt
+++ b/src/main/kotlin/org/purescript/ide/purs/StartupActivity.kt
@@ -19,7 +19,7 @@ class StartupActivity : StartupActivity.Background {
         val rootDir = projectDir.toNioPath()
 
         // without a purs bin path we can't annotate with it
-        val pursBin = Purs().nodeModulesVersion(rootDir) ?: return
+        val pursBin = Purs.nodeModulesVersion(project) ?: return
 
         val command = GeneralCommandLine(pursBin.toString(), "ide", "server")
             .withWorkDirectory(rootDir.toFile())
@@ -32,7 +32,6 @@ class StartupActivity : StartupActivity.Background {
                 CapturingProcessHandler(command)
                     .runProcessWithProgressIndicator(indicator)
             }
-
         }
         task.queue()
     }


### PR DESCRIPTION
The plugin will use the global `purs` if the project `purs` is not installed