### PR TITLE
Extend workaround to unicode arrow

### DIFF
--- a/src/main/kotlin/org/purescript/ide/inspections/PSUnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/org/purescript/ide/inspections/PSUnresolvedReferenceInspection.kt
@@ -57,7 +57,7 @@ class PSUnresolvedReferenceInspection : LocalInspectionTool() {
                 // TODO Workaround to prevent false positives on class constraints
                 val isClassConstraint = reference.element.parent
                     .siblings(forward = true, withSelf = false)
-                    .any { it.text == "=>" }
+                    .any { it.text == "=>" || it.text == "⇒" }
                 if (isClassConstraint) {
                     return
                 }


### PR DESCRIPTION
Triggers the workaround also for unicode arrows.