### PR TITLE
Make `purs-tidy` respect its configuration file

### DIFF
--- a/src/main/kotlin/org/purescript/ide/formatting/PSExternalFormatter.kt
+++ b/src/main/kotlin/org/purescript/ide/formatting/PSExternalFormatter.kt
@@ -9,6 +9,7 @@ import com.intellij.formatting.service.AsyncFormattingRequest
 import com.intellij.formatting.service.FormattingService
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.components.service
+import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.util.NlsSafe
 import com.intellij.psi.PsiFile
 import org.purescript.file.PSFile
@@ -30,6 +31,7 @@ class PSExternalFormatter : AsyncDocumentFormattingService() {
             val commandLine = GeneralCommandLine()
                 .withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE)
                 .withExePath(pursTidyBin.toString())
+                .withWorkDirectory(project.basePath ?: project.guessProjectDir()?.path)
                 .withParameters(params)
                 .withInput(request.ioFile)
                 .withCharset(StandardCharsets.UTF_8)


### PR DESCRIPTION
It's possible to configure `purs-tidy` via a `.tidyrc.json` file.

For a `.tidyrc.json` file to be picked up by `purs-tidy`, it needs to be in the current working directory when invoking the command.

It is customary to store the `.tidyrc.json` file at the root of one's project. 

This change sets the current working directory to the project root when invoking `purs-tidy` so the file gets correctly picked up.

I tried it out and it works :D