### PR TITLE
Workaround EAP newline issues in HTML

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0-RC")
+    implementation("org.jetbrains:markdown:0.2.0.pre-55")
     testImplementation(platform("org.junit:junit-bom:5.9.1"))
     testImplementation("org.junit.jupiter:junit-jupiter:5.9.1")
     testImplementation("junit:junit:4.13.2")

--- a/src/main/kotlin/org/purescript/features/PSDocumentationProvider.kt
+++ b/src/main/kotlin/org/purescript/features/PSDocumentationProvider.kt
@@ -6,6 +6,10 @@ import com.intellij.openapi.editor.richcopy.HtmlSyntaxInfoUtil
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNamedElement
+import org.intellij.markdown.flavours.commonmark.CommonMarkFlavourDescriptor
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
+import org.intellij.markdown.html.HtmlGenerator
+import org.intellij.markdown.parser.MarkdownParser
 import org.purescript.PSLanguage
 import org.purescript.inference.Inferable
 import org.purescript.module.declaration.Importable
@@ -96,14 +100,10 @@ class PSDocumentationProvider : AbstractDocumentationProvider() {
         val lines = commentText
             .joinToString("\n") { it.trim().removePrefix("-- |") }
             .trimIndent()
-            .lines()
-            .toMutableList()
-        HtmlSyntaxInfoUtil.getHighlightedByLexerAndEncodedAsHtmlCodeSnippet(project, PSLanguage, "", 1f)
-        val initial: MState = MState.Normal(project, "")
-        val markdown = lines.fold(initial) { a, b ->
-            a.process(b)
-        }
-        return markdown.text().trim()
+        val flavour = GFMFlavourDescriptor()
+        val parsedTree = MarkdownParser(flavour).buildMarkdownTreeFromString(lines)
+        val html = HtmlGenerator(lines, parsedTree, flavour).generateHtml()
+        return html.trim()
     }
 
     sealed interface MState {

--- a/src/main/kotlin/org/purescript/features/PSDocumentationProvider.kt
+++ b/src/main/kotlin/org/purescript/features/PSDocumentationProvider.kt
@@ -103,7 +103,7 @@ class PSDocumentationProvider : AbstractDocumentationProvider() {
         val flavour = GFMFlavourDescriptor()
         val parsedTree = MarkdownParser(flavour).buildMarkdownTreeFromString(lines)
         val html = HtmlGenerator(lines, parsedTree, flavour).generateHtml()
-        return html.trim()
+        return html.replace("\n", "<br />").trim()
     }
 
     sealed interface MState {

--- a/src/main/kotlin/org/purescript/run/purs/PursIdeRebuildExternalAnnotator.kt
+++ b/src/main/kotlin/org/purescript/run/purs/PursIdeRebuildExternalAnnotator.kt
@@ -106,15 +106,16 @@ class PursIdeRebuildExternalAnnotator : ExternalAnnotator<PsiFile, Response>() {
 
     // IntelliJ gets very slow on large tooltips
     private fun limitTooltip(message: String): String {
+
         val lines = message.lines()
         val maxLinesToShow = 50
         val maxColumnWidth = 120
         val tooltipLines =
                 if (lines.size < maxLinesToShow) lines
                 else {
-                    val separatorHint = "<br />\n[... ${lines.size - maxLinesToShow} more lines elided]<br />\n"
+                    val separatorHint = "<br />[... ${lines.size - maxLinesToShow} more lines elided]<br />"
                     lines.take(35) + listOf(separatorHint) + lines.takeLast(15)
                 }
-        return tooltipLines.joinToString("<br />\n") { it.take(maxColumnWidth) }
+        return tooltipLines.joinToString("<br />") { it.take(maxColumnWidth) }
     }
 }

--- a/src/main/kotlin/org/purescript/run/purs/PursIdeRebuildExternalAnnotator.kt
+++ b/src/main/kotlin/org/purescript/run/purs/PursIdeRebuildExternalAnnotator.kt
@@ -112,9 +112,9 @@ class PursIdeRebuildExternalAnnotator : ExternalAnnotator<PsiFile, Response>() {
         val tooltipLines =
                 if (lines.size < maxLinesToShow) lines
                 else {
-                    val separatorHint = "<br />[... ${lines.size - maxLinesToShow} more lines elided]<br />"
+                    val separatorHint = "<br />\n[... ${lines.size - maxLinesToShow} more lines elided]<br />\n"
                     lines.take(35) + listOf(separatorHint) + lines.takeLast(15)
                 }
-        return tooltipLines.joinToString("\n<br>") { it.take(maxColumnWidth) }
+        return tooltipLines.joinToString("<br />\n") { it.take(maxColumnWidth) }
     }
 }


### PR DESCRIPTION
This is unfortunately required because the current beta doesn't render newlines in tooltips properly without it.